### PR TITLE
Remove unused detailed PDF generator

### DIFF
--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -338,7 +338,3 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, op
     doc.save(fileName);
 };
 
-// Wrapper che utilizza un layout più leggibile per la sezione interventi
-export const generateFoglioAssistenzaPDFDettagliato = async (foglioData, interventiData) => {
-    await generateFoglioAssistenzaPDF(foglioData, interventiData, { layout: 'detailed' });
-};


### PR DESCRIPTION
## Summary
- clean up unused helper from `pdfGenerator.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a92514540832db4a1e10577f48d9d