### PR TITLE
Set detailed layout as default

### DIFF
--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -16,7 +16,8 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
     const [error, setError] = useState(null);
     const [selectedFogli, setSelectedFogli] = useState(new Set());
     const [stampaLoading, setStampaLoading] = useState(false);
-    const [layoutStampa, setLayoutStampa] = useState('table');
+    // Imposta il layout di stampa predefinito su quello dettagliato
+    const [layoutStampa, setLayoutStampa] = useState('detailed');
     const [successMessage, setSuccessMessage] = useState('');
     const [sendingEmailId, setSendingEmailId] = useState(null);
 
@@ -238,7 +239,7 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
                 )}
 
                 <select value={layoutStampa} onChange={e => setLayoutStampa(e.target.value)}>
-                    <option value="table">Layout Standard</option>
+                    <option value="table">Layout Compatto</option>
                     <option value="detailed">Layout Dettagliato</option>
                 </select>
 

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -20,7 +20,8 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const [showInterventoForm, setShowInterventoForm] = useState(false);
     const [editingIntervento, setEditingIntervento] = useState(null);
     const [stampaSingolaLoading, setStampaSingolaLoading] = useState(false);
-    const [layoutStampa, setLayoutStampa] = useState('table');
+    // Il layout di stampa predefinito diventa quello dettagliato
+    const [layoutStampa, setLayoutStampa] = useState('detailed');
 
     const userRole = session?.user?.role;
     const currentUserId = session?.user?.id;
@@ -207,7 +208,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                 <Link to="/fogli-assistenza" className="button secondary">← Lista Fogli</Link>
                 <div style={{display: 'flex', alignItems: 'center', flexWrap:'wrap', gap:'10px'}}>
                     <select value={layoutStampa} onChange={e => setLayoutStampa(e.target.value)}>
-                        <option value="table">Layout Standard</option>
+                        <option value="table">Layout Compatto</option>
                         <option value="detailed">Layout Dettagliato</option>
                     </select>
                     {canViewThisFoglio && (

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -45,7 +45,8 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, op
     }
 
     const doc = new jsPDF({ orientation: 'p', unit: 'mm', format: 'a4' });
-    const layoutType = options.layout || 'table';
+    // Se non specificato, usa il layout dettagliato come predefinito
+    const layoutType = options.layout || 'detailed';
     let yPosition = 15; // Posizione Y corrente, parte dal margine superiore
     const pageHeight = doc.internal.pageSize.getHeight();
     const pageWidth = doc.internal.pageSize.getWidth();


### PR DESCRIPTION
## Summary
- make the PDF generator default to the detailed layout
- initialise layout selections with `detailed`
- rename compact dropdown label

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a9fea5364832d8f41ffdbadebb6da