### PR TITLE
Add build-time version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Versioning
+
+L'applicazione visualizza la versione corrente nella dashboard. Il numero di versione è letto dal campo `version` di `package.json` ed è disponibile come costante `__APP_VERSION__` durante la build Vite.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,7 +204,7 @@ function App() {
   return ( 
     <div className="app-container">
       <header>
-        <h1>Oilsafe Service Hub CODEX-v1</h1>
+        <h1>Oilsafe Service Hub v{__APP_VERSION__}</h1>
         {session && session.user && (
           <nav>
             <Link to="/">Dashboard</Link>

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -12,12 +12,15 @@ function DashboardPage({ session }) { // Riceve la sessione per personalizzare i
       <h2>Dashboard</h2>
       <p>Benvenuto in Oilsafe Service Hub!</p>
       {/* Mostra un messaggio di benvenuto personalizzato se la sessione utente è attiva */}
-      {session && 
+      {session &&
         <p>
-          Loggato come: <strong>{session.user.full_name || session.user.email}</strong> 
+          Loggato come: <strong>{session.user.full_name || session.user.email}</strong>
           (Ruolo: <strong>{session.user.role}</strong>)
         </p>
       }
+      <p style={{ fontStyle: 'italic', marginTop: '1em' }}>
+        Versione applicazione: {__APP_VERSION__}
+      </p>
       <hr style={{margin: "20px 0"}} />
       <p>Utilizza il menu di navigazione in alto per accedere alle diverse sezioni dell'applicazione.</p>
     </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 })


### PR DESCRIPTION
## Summary
- expose package.json version at build time through Vite
- show the current version in the app header and Dashboard page
- document the new versioning mechanism

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685aa9bacf00832db4196bd6356bb95a