### PR TITLE
Add InterventoCard and mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -182,3 +182,23 @@ header nav { /* Aggiunto per allineare il bottone a destra */
 .button.success.small:hover {
     background-color: #218838;
 }
+
+
+.intervento-card {
+    border: 1px solid #ddd;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background-color: #fff;
+}
+.intervento-card table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 0.5rem;
+}
+.intervento-card td {
+    padding: 0.3rem;
+}
+.intervento-card p {
+    margin: 0.2rem 0;
+    white-space: pre-wrap;
+}

--- a/src/components/InterventoCard.jsx
+++ b/src/components/InterventoCard.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+function InterventoCard({ intervento }) {
+    if (!intervento) return null;
+    const formatDate = (d) => d ? new Date(d).toLocaleDateString() : '-';
+    const tecnicoNome = intervento.tecnici
+        ? `${intervento.tecnici.nome} ${intervento.tecnici.cognome}`
+        : 'N/D';
+    return (
+        <div className="intervento-card">
+            <table>
+                <tbody>
+                    <tr>
+                        <td><strong>Data</strong></td>
+                        <td>{formatDate(intervento.data_intervento_effettivo)}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Tecnico</strong></td>
+                        <td>{tecnicoNome}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Tipo</strong></td>
+                        <td>{intervento.tipo_intervento || '-'}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Ore Lavoro</strong></td>
+                        <td>{intervento.ore_lavoro_effettive || '-'}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Ore Viaggio</strong></td>
+                        <td>{intervento.ore_viaggio || '-'}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Km</strong></td>
+                        <td>{intervento.km_percorsi || '-'}</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Spese</strong></td>
+                        <td>
+                            {intervento.vitto && 'Vitto '}
+                            {intervento.autostrada && 'Autostrada '}
+                            {intervento.alloggio && 'Alloggio'}
+                            {(!intervento.vitto && !intervento.autostrada && !intervento.alloggio) && '-'}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <p><strong>Descrizione Attività:</strong></p>
+            <p>{intervento.descrizione_attivita_svolta_intervento || '-'}</p>
+            <p><strong>Osservazioni:</strong></p>
+            <p>{intervento.osservazioni_intervento || '-'}</p>
+        </div>
+    );
+}
+
+export default InterventoCard;

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, Link, useNavigate, Navigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient'; // Assicurati che il percorso sia corretto
 import InterventoAssistenzaForm from '../components/InterventoAssistenzaForm'; // Assicurati che il percorso sia corretto
+import InterventoCard from '../components/InterventoCard';
 import { generateFoglioAssistenzaPDF } from '../utils/pdfGenerator'; // Assicurati che il percorso sia corretto
 
 function FoglioAssistenzaDetailPage({ session, tecnici }) {
@@ -22,6 +23,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const [stampaSingolaLoading, setStampaSingolaLoading] = useState(false);
     // Il layout di stampa predefinito diventa quello dettagliato
     const [layoutStampa, setLayoutStampa] = useState('detailed');
+    const [isSmallScreen, setIsSmallScreen] = useState(false);
 
     const userRole = session?.user?.role;
     const currentUserId = session?.user?.id;
@@ -87,6 +89,15 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     useEffect(() => {
         fetchFoglioData();
     }, [fetchFoglioData]);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsSmallScreen(window.innerWidth <= 768);
+        };
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
 
     const handleOpenInterventoForm = (interventoToEdit = null) => {
@@ -306,6 +317,13 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                 <p>Nessun intervento registrato per questo foglio.</p>
             )}
             {interventi.length > 0 && (
+                isSmallScreen ? (
+                    <div>
+                        {interventi.map(intervento => (
+                            <InterventoCard key={intervento.id} intervento={intervento} />
+                        ))}
+                    </div>
+                ) : (
                 <div style={{overflowX: 'auto'}}>
                 <table>
                     <thead>
@@ -363,6 +381,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                     </tbody>
                 </table>
                 </div>
+                )
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- create `InterventoCard` component for compact mobile view of interventi
- detect small screens in `FoglioAssistenzaDetailPage` and use cards
- style `.intervento-card` for stacked fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ac26d5f94832db15aa0a38d5b2a6c