### PR TITLE
Adjust foglio edit permissions

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -60,7 +60,14 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
 
     const userRole = session?.user?.role;
     const currentUserId = session?.user?.id;
-    const canSubmitForm = userRole === 'admin' || (!isEditMode && userRole === 'user') || (isEditMode && (userRole === 'manager' || (userRole === 'user' && formCreatoDaUserIdOriginal === currentUserId)));
+    const baseFormPermission =
+        userRole === 'admin' ||
+        (!isEditMode && userRole === 'user') ||
+        (isEditMode && (userRole === 'manager' || (userRole === 'user' && formCreatoDaUserIdOriginal === currentUserId)));
+    const formEditingAllowed =
+        formStatoFoglio !== 'Chiuso' &&
+        !(formStatoFoglio === 'Completato' && !!firmaClientePreview);
+    const canSubmitForm = baseFormPermission && formEditingAllowed;
 
     useEffect(() => {
         if (!pageLoading) {


### PR DESCRIPTION
## Summary
- restrict editing of service sheets based on current state and signature
- allow removing customer signature until the sheet is closed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aff58d304832da5b0a3c3c1945f77