### PR TITLE
Add readonly view for intervento form

### DIFF
--- a/src/components/InterventoAssistenzaForm.jsx
+++ b/src/components/InterventoAssistenzaForm.jsx
@@ -3,18 +3,20 @@
  * "intervento" (service intervention).
  * Depends on `supabaseClient.js` for database operations and expects
  * a list of technicians as props. Parent components provide callbacks
- * to handle save/cancel events.
+ * to handle save/cancel events. When invoked with `readOnly` all
+ * form fields are disabled allowing inspection only.
  */
 import React, { useState, useEffect, useMemo } from 'react'; // Aggiunto useMemo
 import { supabase } from '../supabaseClient'; // Assicurati che il percorso sia corretto
 
-function InterventoAssistenzaForm({ 
-    session, 
-    foglioAssistenzaId, 
-    tecniciList, 
-    interventoToEdit, 
-    onInterventoSaved, 
-    onCancel 
+function InterventoAssistenzaForm({
+    session,
+    foglioAssistenzaId,
+    tecniciList,
+    interventoToEdit,
+    onInterventoSaved,
+    onCancel,
+    readOnly = false
 }) {
     const isEditMode = !!interventoToEdit;
 
@@ -75,6 +77,7 @@ function InterventoAssistenzaForm({
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+        if (readOnly) return;
         setLoading(true);
         setError(null);
 
@@ -151,8 +154,9 @@ function InterventoAssistenzaForm({
 
     return (
         <div style={{ border: '1px solid #007bff', padding: '1rem', marginTop: '1rem', borderRadius: '5px', backgroundColor:'#f0f8ff' }}>
-          <h4>{isEditMode ? 'Modifica Intervento Selezionato' : 'Aggiungi Nuovo Intervento'}</h4>
+          <h4>{isEditMode ? (readOnly ? 'Visualizza Intervento' : 'Modifica Intervento Selezionato') : 'Aggiungi Nuovo Intervento'}</h4>
           <form onSubmit={handleSubmit}>
+            <fieldset disabled={readOnly} style={{border:0, padding:0, margin:0}}>
             <div>
               <label htmlFor="formDataIntervento">Data Intervento:</label>
               <input type="date" id="formDataIntervento" value={formDataIntervento} onChange={(e) => setFormDataIntervento(e.target.value)} required />
@@ -236,14 +240,15 @@ function InterventoAssistenzaForm({
                 </div>
               </>
             )}
-             <div>
+            <div>
               <label htmlFor="formOsservazioni">Osservazioni Intervento:</label>
               <textarea id="formOsservazioni" value={formOsservazioni} onChange={(e) => setFormOsservazioni(e.target.value)} />
             </div>
+            </fieldset>
 
             {error && <p style={{ color: 'red', fontWeight:'bold' }}>ERRORE: {error}</p>}
             <div style={{marginTop:'20px'}}>
-                <button type="submit" disabled={loading}>{loading ? "Salvataggio..." : (isEditMode ? "Salva Modifiche Intervento" : "Aggiungi Intervento")}</button>
+                <button type="submit" disabled={loading || readOnly}>{loading ? "Salvataggio..." : (isEditMode ? "Salva Modifiche Intervento" : "Aggiungi Intervento")}</button>
                 <button type="button" className="secondary" onClick={onCancel} disabled={loading} style={{marginLeft:'10px'}}>
                     Annulla
                 </button>

--- a/src/components/InterventoCard.jsx
+++ b/src/components/InterventoCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function InterventoCard({ intervento, canModify, onEdit, onDelete }) {
+function InterventoCard({ intervento, canModify, onEdit, onDelete, onView }) {
     if (!intervento) return null;
     const formatDate = (d) => d ? new Date(d).toLocaleDateString() : '-';
     const tecnicoNome = intervento.tecnici
@@ -49,7 +49,7 @@ function InterventoCard({ intervento, canModify, onEdit, onDelete }) {
             <p>{intervento.descrizione_attivita_svolta_intervento || '-'}</p>
             <p><strong>Osservazioni:</strong></p>
             <p>{intervento.osservazioni_intervento || '-'}</p>
-            {canModify && (
+            {canModify ? (
                 <div className="actions" style={{ marginTop: '0.5rem' }}>
                     <button
                         className="button secondary small"
@@ -65,6 +65,17 @@ function InterventoCard({ intervento, canModify, onEdit, onDelete }) {
                         Elimina
                     </button>
                 </div>
+            ) : (
+                onView && (
+                    <div className="actions" style={{ marginTop: '0.5rem' }}>
+                        <button
+                            className="button secondary small"
+                            onClick={() => onView(intervento)}
+                        >
+                            Visualizza
+                        </button>
+                    </div>
+                )
             )}
         </div>
     );

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -20,6 +20,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const [error, setError] = useState(null);
     const [showInterventoForm, setShowInterventoForm] = useState(false);
     const [editingIntervento, setEditingIntervento] = useState(null);
+    const [interventoFormReadOnly, setInterventoFormReadOnly] = useState(false);
     const [stampaSingolaLoading, setStampaSingolaLoading] = useState(false);
     // Il layout di stampa predefinito diventa quello dettagliato
     const [layoutStampa, setLayoutStampa] = useState('detailed');
@@ -109,12 +110,13 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     }, []);
 
 
-    const handleOpenInterventoForm = (interventoToEdit = null) => {
-        if (!canModifyInterventi) {
+    const handleOpenInterventoForm = (interventoToEdit = null, readOnly = false) => {
+        if (!canModifyInterventi && !readOnly) {
             alert("Interventi non modificabili per questo foglio.");
             return;
         }
         setEditingIntervento(interventoToEdit);
+        setInterventoFormReadOnly(readOnly);
         setShowInterventoForm(true);
         const formElement = document.getElementById('intervento-form-section');
         if (formElement) formElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -122,7 +124,8 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
 
     const handleCloseInterventoForm = () => {
         setShowInterventoForm(false);
-        setEditingIntervento(null); 
+        setEditingIntervento(null);
+        setInterventoFormReadOnly(false);
     };
 
     const handleInterventoSaved = () => { 
@@ -311,14 +314,15 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                 </button>
             )}
 
-            {showInterventoForm && canModifyInterventi && (
+            {showInterventoForm && (
                 <InterventoAssistenzaForm
                     session={session}
                     foglioAssistenzaId={foglioId}
                     tecniciList={tecnici || []}
                     interventoToEdit={editingIntervento}
-                    onInterventoSaved={handleInterventoSaved} 
-                    onCancel={handleCloseInterventoForm}    
+                    readOnly={interventoFormReadOnly}
+                    onInterventoSaved={handleInterventoSaved}
+                    onCancel={handleCloseInterventoForm}
                 />
             )}
 
@@ -335,6 +339,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                                 canModify={canModifyInterventi}
                                 onEdit={() => handleOpenInterventoForm(intervento)}
                                 onDelete={() => handleDeleteIntervento(intervento.id)}
+                                onView={() => handleOpenInterventoForm(intervento, true)}
                             />
                         ))}
                     </div>
@@ -352,7 +357,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                             <th style={{minWidth:'200px'}}>Descrizione Attività</th>
                             <th style={{minWidth:'150px'}}>Osservazioni Intervento</th>
                             <th>Spese</th>
-                            {canModifyInterventi && <th>Azioni</th>}
+                            <th>Azioni</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -372,25 +377,35 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                                 {intervento.alloggio && "Alloggio"}
                                 {(!intervento.vitto && !intervento.autostrada && !intervento.alloggio) && "-"}
                             </td>
-                            {canModifyInterventi && (
-                                <td className="actions">
+                            <td className="actions">
+                                {canModifyInterventi ? (
+                                    <>
+                                        <button
+                                            className="button secondary small"
+                                            onClick={() => handleOpenInterventoForm(intervento)}
+                                            disabled={actionLoading || showInterventoForm}
+                                            style={{marginRight:'5px'}}
+                                        >
+                                            Modifica
+                                        </button>
+                                        <button
+                                            className="button danger small"
+                                            onClick={() => handleDeleteIntervento(intervento.id)}
+                                            disabled={actionLoading}
+                                        >
+                                            Elimina
+                                        </button>
+                                    </>
+                                ) : (
                                     <button
                                         className="button secondary small"
-                                        onClick={() => handleOpenInterventoForm(intervento)}
+                                        onClick={() => handleOpenInterventoForm(intervento, true)}
                                         disabled={actionLoading || showInterventoForm}
-                                        style={{marginRight:'5px'}}
                                     >
-                                        Modifica
+                                        Visualizza
                                     </button>
-                                    <button
-                                        className="button danger small"
-                                        onClick={() => handleDeleteIntervento(intervento.id)}
-                                        disabled={actionLoading}
-                                    >
-                                        Elimina
-                                    </button>
-                                </td>
-                            )}
+                                )}
+                            </td>
                         </tr>
                         ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- add `readOnly` prop to `InterventoAssistenzaForm` and disable form fields when used
- allow opening intervento form in read-only mode from the detail page
- add `Visualizza` button for interventions when the user can't edit

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b00d54370832d967ef0015bd0bf66