### PR TITLE
Fix role recognition for permissions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,27 +63,94 @@ function App() {
             setSession(null); return;
         }
         try {
-            const profilePromise = supabase.from('profiles').select('role, full_name').eq('id', currentAuthSession.user.id).single();
+            const profilePromise = supabase
+                .from('profiles')
+                .select('role, full_name')
+                .eq('id', currentAuthSession.user.id)
+                .single();
             const timeoutDuration = isTabFocusRelatedEvent ? 5000 : 7000;
             const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error(`Timeout fetch profilo (${timeoutDuration/1000} secondi)`)), timeoutDuration));
             const { data: profile, error: profileError } = await Promise.race([profilePromise, timeoutPromise]);
             if (profileError) {
-                if (currentReactSessionForFallback?.user?.id === currentAuthSession.user.id && currentReactSessionForFallback.user.role) {
-                    setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, role: currentReactSessionForFallback.user.role, full_name: currentReactSessionForFallback.user.full_name } });
+                if (
+                    currentReactSessionForFallback?.user?.id === currentAuthSession.user.id &&
+                    currentReactSessionForFallback.user.role
+                ) {
+                    const newSession = {
+                        ...currentAuthSession,
+                        user: {
+                            ...currentAuthSession.user,
+                            role: (currentReactSessionForFallback.user.role || 'user').trim().toLowerCase(),
+                            full_name: currentReactSessionForFallback.user.full_name,
+                        },
+                    };
+                    setSession(newSession);
+                    console.debug('APP.JSX: setSession fallback role', newSession.user.role);
                 } else {
-                    setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, role: 'user', full_name: currentAuthSession.user.email } });
+                    const newSession = {
+                        ...currentAuthSession,
+                        user: {
+                            ...currentAuthSession.user,
+                            role: 'user',
+                            full_name: currentAuthSession.user.email,
+                        },
+                    };
+                    setSession(newSession);
+                    console.debug('APP.JSX: setSession default role', newSession.user.role);
                 }
             } else if (profile) {
-                setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, ...profile } });
-            } else { 
-                setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, role: 'user', full_name: currentAuthSession.user.email } });
+                const normalizedRole = (profile.role || 'user').trim().toLowerCase();
+                const newSession = {
+                    ...currentAuthSession,
+                    user: {
+                        ...currentAuthSession.user,
+                        ...profile,
+                        role: normalizedRole,
+                    },
+                };
+                setSession(newSession);
+                console.debug('APP.JSX: setSession profile role', newSession.user.role);
+            } else {
+                const newSession = {
+                    ...currentAuthSession,
+                    user: {
+                        ...currentAuthSession.user,
+                        role: 'user',
+                        full_name: currentAuthSession.user.email,
+                    },
+                };
+                setSession(newSession);
+                console.debug('APP.JSX: setSession no profile role', newSession.user.role);
             }
         } catch (e) {
-            if (currentReactSessionForFallback?.user?.id === currentAuthSession?.user?.id && currentReactSessionForFallback.user.role) {
-                setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, role: currentReactSessionForFallback.user.role, full_name: currentReactSessionForFallback.user.full_name } });
+            if (
+                currentReactSessionForFallback?.user?.id === currentAuthSession?.user?.id &&
+                currentReactSessionForFallback.user.role
+            ) {
+                const newSession = {
+                    ...currentAuthSession,
+                    user: {
+                        ...currentAuthSession.user,
+                        role: (currentReactSessionForFallback.user.role || 'user').trim().toLowerCase(),
+                        full_name: currentReactSessionForFallback.user.full_name,
+                    },
+                };
+                setSession(newSession);
+                console.debug('APP.JSX: setSession exception fallback role', newSession.user.role);
             } else if (currentAuthSession && currentAuthSession.user) {
-                setSession({ ...currentAuthSession, user: { ...currentAuthSession.user, role: 'user', full_name: currentAuthSession.user.email } });
-            } else { setSession(null); }
+                const newSession = {
+                    ...currentAuthSession,
+                    user: {
+                        ...currentAuthSession.user,
+                        role: 'user',
+                        full_name: currentAuthSession.user.email,
+                    },
+                };
+                setSession(newSession);
+                console.debug('APP.JSX: setSession exception default role', newSession.user.role);
+            } else {
+                setSession(null);
+                }
         }
     };
 
@@ -198,7 +265,7 @@ function App() {
     );
   }
 
-  const userRole = session?.user?.role;
+  const userRole = (session?.user?.role || '').trim().toLowerCase();
   const canCreateNewSheet = userRole === 'admin' || userRole === 'user';
 
   return ( 

--- a/src/components/anagrafiche/ClientiManager.jsx
+++ b/src/components/anagrafiche/ClientiManager.jsx
@@ -39,7 +39,7 @@ function ClientiManager({ session }) {
     const [formEditIndirizzoCompleto, setFormEditIndirizzoCompleto] = useState('');
     const [formEditIndirizzoDescrizione, setFormEditIndirizzoDescrizione] = useState('');
 
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const canManage = userRole === 'admin' || userRole === 'manager';
     const fileInputRef = useRef(null);
 

--- a/src/components/anagrafiche/CommesseManager.jsx
+++ b/src/components/anagrafiche/CommesseManager.jsx
@@ -38,7 +38,7 @@ function CommesseManager({ session, clienti }) { // `clienti` prop è usato per 
     const [ricercaSbloccata, setRicercaSbloccata] = useState(false);
 
     // Ruolo utente e permessi
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const canManage = userRole === 'admin' || userRole === 'manager';
 
     // Ref per input file e debounce

--- a/src/components/anagrafiche/OrdiniClienteManager.jsx
+++ b/src/components/anagrafiche/OrdiniClienteManager.jsx
@@ -39,7 +39,7 @@ function OrdiniClienteManager({ session, clienti, commesse }) {
     const [ricercaSbloccata, setRicercaSbloccata] = useState(false);
 
     // Ruolo utente e permessi
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const canManage = userRole === 'admin' || userRole === 'manager';
 
     // Ref per input file e debounce

--- a/src/components/anagrafiche/TecniciManager.jsx
+++ b/src/components/anagrafiche/TecniciManager.jsx
@@ -25,7 +25,7 @@ function TecniciManager({ session }) {
     const [formEmail, setFormEmail] = useState('');
     const [editingTecnico, setEditingTecnico] = useState(null);
 
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const canManage = userRole === 'admin' || userRole === 'manager';
     const fileInputRef = useRef(null);
 

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -30,7 +30,7 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
     const [filtroOrdineTesto, setFiltroOrdineTesto] = useState('');
     const [filtroStato, setFiltroStato] = useState(''); // NUOVO STATO PER IL FILTRO STATO ('' significa 'Tutti')
     
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const currentUserId = session?.user?.id;
 
     // Funzione per caricare i dati dei fogli dal server

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -26,7 +26,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const [layoutStampa, setLayoutStampa] = useState('detailed');
     const [isSmallScreen, setIsSmallScreen] = useState(false);
 
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const currentUserId = session?.user?.id;
 
     // Calcola i permessi dopo che `foglio` è stato caricato
@@ -37,6 +37,14 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
         foglio &&
         foglio.stato_foglio !== 'Chiuso' &&
         !(foglio.stato_foglio === 'Completato' && foglio.firma_cliente_url);
+    console.debug('FADetail perms', {
+        userRole,
+        currentUserId,
+        foglioCreator: foglio?.creato_da_user_id,
+        foglioStato: foglio?.stato_foglio,
+        baseEditPermission,
+        canEditThisFoglioOverall,
+    });
     const canRemoveFirmaCliente =
         baseEditPermission &&
         foglio &&

--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -58,7 +58,7 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     const [firmaClientePreview, setFirmaClientePreview] = useState(null);
     const [firmaTecnicoPreview, setFirmaTecnicoPreview] = useState(null);
 
-    const userRole = session?.user?.role;
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
     const currentUserId = session?.user?.id;
     const baseFormPermission =
         userRole === 'admin' ||
@@ -68,6 +68,16 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         formStatoFoglio !== 'Chiuso' &&
         !(formStatoFoglio === 'Completato' && !!firmaClientePreview);
     const canSubmitForm = baseFormPermission && formEditingAllowed;
+    console.debug('FAPage perms', {
+        userRole,
+        currentUserId,
+        formCreatoDaUserIdOriginal,
+        isEditMode,
+        formStatoFoglio,
+        baseFormPermission,
+        formEditingAllowed,
+        canSubmitForm,
+    });
 
     useEffect(() => {
         if (!pageLoading) {


### PR DESCRIPTION
## Summary
- normalize user role strings to avoid case or whitespace issues
- apply normalization when setting session roles
- update permission checks across components to use the normalized role
- add console debugging when setting session and evaluating permissions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b9c8a4508832db0395cf14ca8d069