### PR TITLE
Update edit permissions for service sheets

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -62,20 +62,36 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     const currentUserId = session?.user?.id;
     const baseFormPermission =
         userRole === 'admin' ||
-        (!isEditMode && userRole === 'user') ||
-        (isEditMode && (userRole === 'manager' || (userRole === 'user' && formCreatoDaUserIdOriginal === currentUserId)));
-    const formEditingAllowed =
-        formStatoFoglio !== 'Chiuso' &&
-        !(formStatoFoglio === 'Completato' && !!firmaClientePreview);
-    const canSubmitForm = baseFormPermission && formEditingAllowed;
+        (!isEditMode && (userRole === 'user' || userRole === 'manager')) ||
+        (isEditMode &&
+            (userRole === 'admin' ||
+                userRole === 'manager' ||
+                (userRole === 'user' && formCreatoDaUserIdOriginal === currentUserId)));
+
+    const isChiuso = formStatoFoglio === 'Chiuso';
+    const isCompletato = formStatoFoglio === 'Completato';
+    const firmaPresente = !!firmaClientePreview;
+
+    let canSubmitForm = false;
+    if (!isEditMode) {
+        canSubmitForm = baseFormPermission;
+    } else if (baseFormPermission) {
+        if (userRole === 'admin') {
+            canSubmitForm = true;
+        } else if (userRole === 'manager') {
+            canSubmitForm = !isChiuso;
+        } else if (userRole === 'user' && formCreatoDaUserIdOriginal === currentUserId) {
+            canSubmitForm = !isChiuso && !isCompletato && !firmaPresente;
+        }
+    }
+
     console.debug('FAPage perms', {
         userRole,
         currentUserId,
         formCreatoDaUserIdOriginal,
         isEditMode,
         formStatoFoglio,
-        baseFormPermission,
-        formEditingAllowed,
+        firmaPresente,
         canSubmitForm,
     });
 


### PR DESCRIPTION
## Summary
- fix global permission checks for fogli di assistenza
- allow admin editing even when sheet is closed
- permit manager editing on completed sheets
- log more debug info about permissions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bb34ce950832da0503370c89a6e1e