### PR TITLE
Fix customer name filter in commesse list

### DIFF
--- a/src/components/anagrafiche/CommesseManager.jsx
+++ b/src/components/anagrafiche/CommesseManager.jsx
@@ -77,9 +77,18 @@ function CommesseManager({ session, clienti }) { // `clienti` prop è usato per 
         const from = (currentPage - 1) * RIGHE_PER_PAGINA;
         const to = currentPage * RIGHE_PER_PAGINA - 1;
 
+        // Se l'utente filtra per nome cliente è necessario usare un INNER JOIN
+        // su "clienti" per applicare correttamente il filtro server-side.
+        let selectColumns =
+            'id, codice_commessa, descrizione_commessa, stato, cliente_id, clienti (id, nome_azienda)';
+        if (filtroServerClienteNome) {
+            selectColumns =
+                'id, codice_commessa, descrizione_commessa, stato, cliente_id, clienti!inner (id, nome_azienda)';
+        }
+
         let query = supabase
             .from('commesse')
-            .select(`id, codice_commessa, descrizione_commessa, stato, cliente_id, clienti (id, nome_azienda)`, { count: 'exact' })
+            .select(selectColumns, { count: 'exact' })
             .order('codice_commessa', { ascending: true })
             .range(from, to);
 


### PR DESCRIPTION
## Summary
- join `clienti` with `!inner` when filtering by customer name so that the filter is applied on the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d16b27cdc832d85bb1dd8779ca176