### PR TITLE
Enable technician editing

### DIFF
--- a/database query/27. Policy fogli_assistenza.sql
+++ b/database query/27. Policy fogli_assistenza.sql
@@ -36,12 +36,34 @@ CREATE POLICY "User CRUD on own fogli_assistenza for insert"
 
 CREATE POLICY "User CRUD on own fogli_assistenza for select"
   ON public.fogli_assistenza FOR SELECT
-  USING (public.get_my_role() = 'user' AND auth.uid() = creato_da_user_id);
+  USING (
+    public.get_my_role() = 'user' AND (
+      auth.uid() = creato_da_user_id OR
+      EXISTS (
+        SELECT 1 FROM public.interventi_assistenza ia
+        JOIN public.tecnici t ON t.id = ia.tecnico_id
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE ia.foglio_assistenza_id = fogli_assistenza.id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
+    )
+  );
   -- Per update, il check implicito è che l'utente stia modificando un record che già vede (quindi il suo)
   
 CREATE POLICY "User CRUD on own fogli_assistenza for update"
   ON public.fogli_assistenza FOR UPDATE
-  USING (public.get_my_role() = 'user' AND auth.uid() = creato_da_user_id);
+  USING (
+    public.get_my_role() = 'user' AND (
+      auth.uid() = creato_da_user_id OR
+      EXISTS (
+        SELECT 1 FROM public.interventi_assistenza ia
+        JOIN public.tecnici t ON t.id = ia.tecnico_id
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE ia.foglio_assistenza_id = fogli_assistenza.id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
+    )
+  );
   -- Per update, il check implicito è che l'utente stia modificando un record che già vede (quindi il suo)
 
 CREATE POLICY "User CRUD on own fogli_assistenza for delete"

--- a/database query/28. Policy interventi_assistenza.sql
+++ b/database query/28. Policy interventi_assistenza.sql
@@ -34,9 +34,17 @@ CREATE POLICY "User CRUD on own interventi_assistenza for select"
   ON public.interventi_assistenza FOR SELECT
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
@@ -44,9 +52,17 @@ CREATE POLICY "User CRUD on own interventi_assistenza for update"
   ON public.interventi_assistenza FOR UPDATE
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
@@ -54,9 +70,17 @@ CREATE POLICY "User CRUD on own interventi_assistenza for delete"
   ON public.interventi_assistenza FOR DELETE
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
@@ -67,8 +91,16 @@ CREATE POLICY "User CRUD on own interventi_assistenza for insert"
   ON public.interventi_assistenza FOR INSERT
   WITH CHECK (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -50,12 +50,11 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
                 id, numero_foglio, data_apertura_foglio, stato_foglio, creato_da_user_id,
                 cliente_id, commessa_id, ordine_cliente_id,
                 email_report_cliente, email_report_interno,
-                interventi_assistenza!left(tecnico_id)
+                interventi_assistenza!left(tecnico_id, tecnici (email))
             `)
             .order('data_apertura_foglio', { ascending: false });
 
         // Applica filtri server-side (solo per data, che è più efficiente)
-        if (userRole === 'user') query = query.eq('creato_da_user_id', currentUserId);
         if (filtroDataDa) query = query.gte('data_apertura_foglio', filtroDataDa);
         if (filtroDataA) {
             const dataAEndDate = new Date(filtroDataA);


### PR DESCRIPTION
## Summary
- extend RLS policies on fogli_assistenza and interventi_assistenza to allow access for assigned technicians
- fetch technician email when reading interventions
- compute permissions based on assigned technician
- let Supabase RLS filter visible sheets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e514589d0832d95190ffc354c91b6