### PR TITLE
Enable technician editing

### DIFF
--- a/database query/28. Policy interventi_assistenza.sql
+++ b/database query/28. Policy interventi_assistenza.sql
@@ -5,16 +5,19 @@ ALTER TABLE public.interventi_assistenza ENABLE ROW LEVEL SECURITY;
 -- Rimuovi vecchie policy generiche...
 
 -- ADMIN: tutti i permessi
+DROP POLICY IF EXISTS "Admin full access on interventi_assistenza" ON public.interventi_assistenza;
 CREATE POLICY "Admin full access on interventi_assistenza"
   ON public.interventi_assistenza FOR ALL
   USING (public.get_my_role() = 'admin')
   WITH CHECK (public.get_my_role() = 'admin');
 
 -- MANAGER: visualizzare e modificare i fogli di lavoro di tutti
+DROP POLICY IF EXISTS "Manager read all interventi_assistenza" ON public.interventi_assistenza;
 CREATE POLICY "Manager read all interventi_assistenza"
   ON public.interventi_assistenza FOR SELECT
   USING (public.get_my_role() = 'manager');
 
+DROP POLICY IF EXISTS "Manager update all interventi_assistenza" ON public.interventi_assistenza;
 CREATE POLICY "Manager update all interventi_assistenza"
   ON public.interventi_assistenza FOR UPDATE
   USING (public.get_my_role() = 'manager')
@@ -23,6 +26,7 @@ CREATE POLICY "Manager update all interventi_assistenza"
 
 
 -- HEAD: visualizzare gli interventi di tutti i fogli
+DROP POLICY IF EXISTS "Head read all interventi_assistenza" ON public.interventi_assistenza;
 CREATE POLICY "Head read all interventi_assistenza"
   ON public.interventi_assistenza FOR SELECT
   USING (public.get_my_role() = 'head');
@@ -30,45 +34,81 @@ CREATE POLICY "Head read all interventi_assistenza"
 -- USER: creare, cancellare, modificare interventi SUI PROPRI fogli di lavoro
 -- Per SELECT, UPDATE, DELETE: l'utente può operare su un intervento se il foglio_assistenza_id
 -- corrisponde a un foglio creato da lui.
+DROP POLICY IF EXISTS "User CRUD on own interventi_assistenza for select" ON public.interventi_assistenza;
 CREATE POLICY "User CRUD on own interventi_assistenza for select"
   ON public.interventi_assistenza FOR SELECT
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
+DROP POLICY IF EXISTS "User CRUD on own interventi_assistenza for update" ON public.interventi_assistenza;
 CREATE POLICY "User CRUD on own interventi_assistenza for update"
   ON public.interventi_assistenza FOR UPDATE
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
+DROP POLICY IF EXISTS "User CRUD on own interventi_assistenza for delete" ON public.interventi_assistenza;
 CREATE POLICY "User CRUD on own interventi_assistenza for delete"
   ON public.interventi_assistenza FOR DELETE
   USING (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );
 
 
 -- Per INSERT: l'utente può inserire un intervento se il foglio_assistenza_id
 -- corrisponde a un foglio creato da lui.
+DROP POLICY IF EXISTS "User CRUD on own interventi_assistenza for insert" ON public.interventi_assistenza;
 CREATE POLICY "User CRUD on own interventi_assistenza for insert"
   ON public.interventi_assistenza FOR INSERT
   WITH CHECK (
     public.get_my_role() = 'user' AND
-    EXISTS (
-      SELECT 1 FROM public.fogli_assistenza fa
-      WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+    (
+      EXISTS (
+        SELECT 1 FROM public.fogli_assistenza fa
+        WHERE fa.id = interventi_assistenza.foglio_assistenza_id AND fa.creato_da_user_id = auth.uid()
+      ) OR
+      EXISTS (
+        SELECT 1 FROM public.tecnici t
+        JOIN auth.users u ON u.id = auth.uid()
+        WHERE t.id = interventi_assistenza.tecnico_id
+          AND LOWER(t.email) = LOWER(u.email)
+      )
     )
   );

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -50,12 +50,11 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
                 id, numero_foglio, data_apertura_foglio, stato_foglio, creato_da_user_id,
                 cliente_id, commessa_id, ordine_cliente_id,
                 email_report_cliente, email_report_interno,
-                interventi_assistenza!left(tecnico_id)
+                interventi_assistenza!left(tecnico_id, tecnici (email))
             `)
             .order('data_apertura_foglio', { ascending: false });
 
         // Applica filtri server-side (solo per data, che è più efficiente)
-        if (userRole === 'user') query = query.eq('creato_da_user_id', currentUserId);
         if (filtroDataDa) query = query.gte('data_apertura_foglio', filtroDataDa);
         if (filtroDataA) {
             const dataAEndDate = new Date(filtroDataA);


### PR DESCRIPTION
## Summary
- extend RLS policies on fogli_assistenza and interventi_assistenza to allow access for assigned technicians
- fetch technician email when reading interventions
- compute permissions based on assigned technician
- let Supabase RLS filter visible sheets
- drop existing policies before creating new ones

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e514589d0832d95190ffc354c91b6