### PR TITLE
Add helper function for foglio assignment

### DIFF
--- a/database query/27. Policy fogli_assistenza.sql
+++ b/database query/27. Policy fogli_assistenza.sql
@@ -45,13 +45,7 @@ CREATE POLICY "User CRUD on own fogli_assistenza for select"
   USING (
     public.get_my_role() = 'user' AND (
       auth.uid() = creato_da_user_id OR
-      EXISTS (
-        SELECT 1 FROM public.interventi_assistenza ia
-        JOIN public.tecnici t ON t.id = ia.tecnico_id
-        JOIN auth.users u ON u.id = auth.uid()
-        WHERE ia.foglio_assistenza_id = fogli_assistenza.id
-          AND LOWER(t.email) = LOWER(u.email)
-      )
+      public.is_user_assigned_to_foglio(fogli_assistenza.id)
     )
   );
   -- Per update, il check implicito è che l'utente stia modificando un record che già vede (quindi il suo)
@@ -62,13 +56,7 @@ CREATE POLICY "User CRUD on own fogli_assistenza for update"
   USING (
     public.get_my_role() = 'user' AND (
       auth.uid() = creato_da_user_id OR
-      EXISTS (
-        SELECT 1 FROM public.interventi_assistenza ia
-        JOIN public.tecnici t ON t.id = ia.tecnico_id
-        JOIN auth.users u ON u.id = auth.uid()
-        WHERE ia.foglio_assistenza_id = fogli_assistenza.id
-          AND LOWER(t.email) = LOWER(u.email)
-      )
+      public.is_user_assigned_to_foglio(fogli_assistenza.id)
     )
   );
   -- Per update, il check implicito è che l'utente stia modificando un record che già vede (quindi il suo)

--- a/database query/29. Function is_user_assigned_to_foglio.sql
+++ b/database query/29. Function is_user_assigned_to_foglio.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION public.is_user_assigned_to_foglio(foglio_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  result BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.interventi_assistenza ia
+    JOIN public.tecnici t ON t.id = ia.tecnico_id
+    JOIN auth.users u ON u.id = auth.uid()
+    WHERE ia.foglio_assistenza_id = foglio_id
+      AND LOWER(t.email) = LOWER(u.email)
+  ) INTO result;
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add helper function `is_user_assigned_to_foglio` as SECURITY DEFINER
- use this function in `fogli_assistenza` RLS policies instead of repeating query

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because of missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ea47ff268832d8c7f75047ab653a1