### PR TITLE
Fix RLS check for manager access

### DIFF
--- a/database query/28. Policy interventi_assistenza.sql
+++ b/database query/28. Policy interventi_assistenza.sql
@@ -46,9 +46,8 @@ CREATE POLICY "User CRUD on own interventi_assistenza for select"
       ) OR
       EXISTS (
         SELECT 1 FROM public.tecnici t
-        JOIN auth.users u ON u.id = auth.uid()
         WHERE t.id = interventi_assistenza.tecnico_id
-          AND LOWER(t.email) = LOWER(u.email)
+          AND LOWER(t.email) = LOWER(current_setting('request.jwt.claims', true)::json->>'email')
       )
     )
   );
@@ -65,9 +64,8 @@ CREATE POLICY "User CRUD on own interventi_assistenza for update"
       ) OR
       EXISTS (
         SELECT 1 FROM public.tecnici t
-        JOIN auth.users u ON u.id = auth.uid()
         WHERE t.id = interventi_assistenza.tecnico_id
-          AND LOWER(t.email) = LOWER(u.email)
+          AND LOWER(t.email) = LOWER(current_setting('request.jwt.claims', true)::json->>'email')
       )
     )
   );
@@ -84,9 +82,8 @@ CREATE POLICY "User CRUD on own interventi_assistenza for delete"
       ) OR
       EXISTS (
         SELECT 1 FROM public.tecnici t
-        JOIN auth.users u ON u.id = auth.uid()
         WHERE t.id = interventi_assistenza.tecnico_id
-          AND LOWER(t.email) = LOWER(u.email)
+          AND LOWER(t.email) = LOWER(current_setting('request.jwt.claims', true)::json->>'email')
       )
     )
   );
@@ -106,9 +103,8 @@ CREATE POLICY "User CRUD on own interventi_assistenza for insert"
       ) OR
       EXISTS (
         SELECT 1 FROM public.tecnici t
-        JOIN auth.users u ON u.id = auth.uid()
         WHERE t.id = interventi_assistenza.tecnico_id
-          AND LOWER(t.email) = LOWER(u.email)
+          AND LOWER(t.email) = LOWER(current_setting('request.jwt.claims', true)::json->>'email')
       )
     )
   );

--- a/database query/29. Function is_user_assigned_to_foglio.sql
+++ b/database query/29. Function is_user_assigned_to_foglio.sql
@@ -7,13 +7,15 @@ AS $$
 DECLARE
   result BOOLEAN;
 BEGIN
+  -- Recupera l'email dall'header JWT senza consultare la tabella auth.users
+  -- per evitare errori di permesso quando la funzione è invocata in contesti
+  -- con privilegi limitati.
   SELECT EXISTS (
     SELECT 1
     FROM public.interventi_assistenza ia
     JOIN public.tecnici t ON t.id = ia.tecnico_id
-    JOIN auth.users u ON u.id = auth.uid()
     WHERE ia.foglio_assistenza_id = foglio_id
-      AND LOWER(t.email) = LOWER(u.email)
+      AND LOWER(t.email) = LOWER(current_setting('request.jwt.claims', true)::json->>'email')
   ) INTO result;
   RETURN result;
 END;


### PR DESCRIPTION
## Summary
- avoid querying `auth.users` inside `is_user_assigned_to_foglio`
- reference user email via JWT claims in `interventi_assistenza` policies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eb21f81bc832dab694e0ab5a227fc