### PR TITLE
Add technician assignment dropdown for service sheets

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -318,18 +318,19 @@ function App() {
               path="/fogli-assistenza/nuovo" 
               element={
                 canCreateNewSheet ? 
-                <FoglioAssistenzaFormPage session={session} clienti={clienti} commesse={commesse} ordini={ordini} />
+                <FoglioAssistenzaFormPage session={session} clienti={clienti} commesse={commesse} ordini={ordini} tecnici={tecnici} />
                 : <Navigate to="/" replace />
               }
             />
             <Route 
               path="/fogli-assistenza/:foglioIdParam/modifica"
               element={
-                <FoglioAssistenzaFormPage 
-                    session={session} 
-                    clienti={clienti} 
-                    commesse={commesse} 
-                    ordini={ordini} 
+                <FoglioAssistenzaFormPage
+                    session={session}
+                    clienti={clienti}
+                    commesse={commesse}
+                    ordini={ordini}
+                    tecnici={tecnici}
                 />
               }
             />


### PR DESCRIPTION
## Summary
- allow choosing reference technician when creating or editing a service sheet
- send selected technician id to Supabase and load it when editing
- include technicians list prop from `App.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fafa960c8832dad0384af70630295