### PR TITLE
Fix header edit crash

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -24,6 +24,10 @@ function FoglioAssistenzaFormPage({ session, clienti, commesse, ordini, tecnici 
     const { foglioIdParam } = useParams();
     const isEditMode = !!foglioIdParam;
 
+    const userRole = (session?.user?.role || '').trim().toLowerCase();
+    const currentUserId = session?.user?.id;
+    const currentUserEmail = session?.user?.email?.toLowerCase();
+
     const draftKey = foglioIdParam ? `draft-foglio-${foglioIdParam}` : 'draft-foglio-new';
 
     // Stati del Form
@@ -60,9 +64,6 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     const [firmaClientePreview, setFirmaClientePreview] = useState(null);
     const [firmaTecnicoPreview, setFirmaTecnicoPreview] = useState(null);
 
-    const userRole = (session?.user?.role || '').trim().toLowerCase();
-    const currentUserId = session?.user?.id;
-    const currentUserEmail = session?.user?.email?.toLowerCase();
     const [isAssignedTecnico, setIsAssignedTecnico] = useState(false);
     const baseFormPermission =
         userRole === 'admin' ||


### PR DESCRIPTION
## Summary
- fix runtime ReferenceError when opening header edit by initializing user data before useState hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fc1ac6274832d9d40ee1082b5204c