### PR TITLE
Fix technician dropdown filtering

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -319,9 +319,8 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     [tecnici]);
     const tecniciFiltrati = useMemo(() =>
         tecniciOrdinati.filter(t =>
-            (t.cognome.toLowerCase().includes(filtroTecnico.toLowerCase()) ||
-            t.nome.toLowerCase().includes(filtroTecnico.toLowerCase())) &&
-            t.user_id
+            t.cognome.toLowerCase().includes(filtroTecnico.toLowerCase()) ||
+            t.nome.toLowerCase().includes(filtroTecnico.toLowerCase())
         ),
     [tecniciOrdinati, filtroTecnico]);
 
@@ -386,8 +385,12 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
                     >
                         <option value="">Seleziona Tecnico ({tecniciFiltrati.length})</option>
                         {tecniciFiltrati.map(t => (
-                            <option key={t.id} value={t.user_id}>
-                                {t.cognome} {t.nome}
+                            <option
+                                key={t.id}
+                                value={t.user_id || ''}
+                                disabled={!t.user_id}
+                            >
+                                {t.cognome} {t.nome}{t.email ? ` (${t.email})` : ''}
                             </option>
                         ))}
                     </select>


### PR DESCRIPTION
## Summary
- include all technicians in foglio form dropdown
- show technician email in dropdown and disable entries without linked user

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68600c8d5508832dac5ec1d27a20ee97