### PR TITLE
Fix technician select messaging

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -324,6 +324,11 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         ),
     [tecniciOrdinati, filtroTecnico]);
 
+    const allTecniciDisabilitati = useMemo(
+        () => tecniciFiltrati.every(t => !t.user_id),
+        [tecniciFiltrati]
+    );
+
     const canEditAssignedTecnico = userRole === 'admin' || userRole === 'manager';
 
     if (pageLoading && isEditMode) return <p>Caricamento dati foglio...</p>;
@@ -390,10 +395,13 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
                                 value={t.user_id || ''}
                                 disabled={!t.user_id}
                             >
-                                {t.cognome} {t.nome}{t.email ? ` (${t.email})` : ''}
+                                {t.cognome} {t.nome}{t.email ? ` (${t.email})` : ''}{!t.user_id ? ' (account mancante)' : ''}
                             </option>
                         ))}
                     </select>
+                    {allTecniciDisabilitati && (
+                        <p style={{fontSize:'0.9em', color:'#c00'}}>Nessun tecnico con account disponibile.</p>
+                    )}
                 </div>
                 <div>
                     <label htmlFor="commessa">Commessa:</label>


### PR DESCRIPTION
## Summary
- highlight missing technician accounts in dropdown
- warn when no selectable technician is available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860116202b8832daa9212f3e27a0dfb