### PR TITLE
Validate tecnico profile id

### DIFF
--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -239,7 +239,19 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         }
 
         try {
-            let firmaClienteUrlToSave = firmaClientePreview; 
+            const { data: profCheck, error: profError } = await supabase
+                .from('profiles')
+                .select('id')
+                .eq('id', formAssignedTecnicoId)
+                .maybeSingle();
+            if (profError) throw profError;
+            if (!profCheck) {
+                setError('Tecnico non collegato a un account utente.');
+                setLoadingSubmit(false);
+                return;
+            }
+
+            let firmaClienteUrlToSave = firmaClientePreview;
             let firmaTecnicoUrlToSave = firmaTecnicoPreview;
             // Logica di upload firme completa
             if (sigCanvasClienteRef.current && !sigCanvasClienteRef.current.isEmpty()) {


### PR DESCRIPTION
## Summary
- check for a `profiles` row matching the tecnico before saving a foglio

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686017797500832d9ba5f1b6f7271d55