### PR TITLE
Fix technician filter for empty strings

### DIFF
--- a/src/components/InterventoAssistenzaForm.jsx
+++ b/src/components/InterventoAssistenzaForm.jsx
@@ -145,9 +145,9 @@ function InterventoAssistenzaForm({
     [tecniciList]);
 
     const tecniciFiltrati = useMemo(() =>
-        tecniciOrdinati.filter(t => 
-            t.cognome.toLowerCase().includes(filtroTecnico.toLowerCase()) ||
-            t.nome.toLowerCase().includes(filtroTecnico.toLowerCase())
+        tecniciOrdinati.filter(t =>
+            (t.cognome || '').toLowerCase().includes(filtroTecnico.toLowerCase()) ||
+            (t.nome || '').toLowerCase().includes(filtroTecnico.toLowerCase())
         ),
     [tecniciOrdinati, filtroTecnico]);
 

--- a/src/components/anagrafiche/TecniciManager.jsx
+++ b/src/components/anagrafiche/TecniciManager.jsx
@@ -33,7 +33,7 @@ function TecniciManager({ session }) {
     const fileInputRef = useRef(null);
     const filteredUsers = useMemo(
         () => users.filter(u =>
-            u.username.toLowerCase().includes(filterUser.toLowerCase()) ||
+            (u.username || '').toLowerCase().includes(filterUser.toLowerCase()) ||
             (u.full_name || '').toLowerCase().includes(filterUser.toLowerCase())
         ),
         [users, filterUser]

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -129,7 +129,11 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
         if (filtroClienteTesto.trim()) { dataDaFiltrare = dataDaFiltrare.filter(f => f.cliente_nome_azienda.toLowerCase().includes(filtroClienteTesto.toLowerCase())); }
         if (filtroCommessaTesto.trim()) { dataDaFiltrare = dataDaFiltrare.filter(f => f.commessa_codice.toLowerCase().includes(filtroCommessaTesto.toLowerCase())); }
         if (filtroOrdineTesto.trim()) { dataDaFiltrare = dataDaFiltrare.filter(f => f.ordine_numero.toLowerCase().includes(filtroOrdineTesto.toLowerCase())); }
-        if (filtroTecnicoTesto.trim()) { dataDaFiltrare = dataDaFiltrare.filter(f => f.nomi_tecnici_coinvolti.toLowerCase().includes(filtroTecnicoTesto.toLowerCase())); }
+        if (filtroTecnicoTesto.trim()) {
+            dataDaFiltrare = dataDaFiltrare.filter(f =>
+                (f.nomi_tecnici_coinvolti || '').toLowerCase().includes(filtroTecnicoTesto.toLowerCase())
+            );
+        }
         
         return dataDaFiltrare;
     }, [fogli, filtroStato, filtroClienteTesto, filtroCommessaTesto, filtroOrdineTesto, filtroTecnicoTesto]);

--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -331,8 +331,8 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     [tecnici]);
     const tecniciFiltrati = useMemo(() =>
         tecniciOrdinati.filter(t =>
-            t.cognome.toLowerCase().includes(filtroTecnico.toLowerCase()) ||
-            t.nome.toLowerCase().includes(filtroTecnico.toLowerCase())
+            (t.cognome || '').toLowerCase().includes(filtroTecnico.toLowerCase()) ||
+            (t.nome || '').toLowerCase().includes(filtroTecnico.toLowerCase())
         ),
     [tecniciOrdinati, filtroTecnico]);
 


### PR DESCRIPTION
## Summary
- null-safe lowercase check for usernames in TecniciManager
- guard against null technician names when filtering dropdowns
- handle missing names in FogliAssistenza list filter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686073295e74832db8593b26be7d7dd1