### PR TITLE
Add migration for tecnici user_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ L'applicazione visualizza la versione corrente nella dashboard. Il numero di ver
 - `29. Function is_user_assigned_to_foglio.sql` also checks the `assegnato_a_user_id` field.
 - `52. FK fogli_assistenza assegnato_a_profiles.sql` links `fogli_assistenza.assegnato_a_user_id` to `public.profiles.id`.
 - Technicians must have a `user_id` linked to `public.profiles` to be selectable when compiling a service sheet.
+- `53. Alter tecnici add user_id.sql` creates a `user_id` field in `tecnici` referencing `public.profiles`.

--- a/database query/53. Alter tecnici add user_id.sql
+++ b/database query/53. Alter tecnici add user_id.sql
@@ -1,0 +1,3 @@
+-- Adds a user_id column to link technicians with user profiles
+ALTER TABLE public.tecnici
+  ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES public.profiles(id);


### PR DESCRIPTION
## Summary
- add SQL migration to include a `user_id` column in `tecnici`
- document the new migration in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686076b167b0832d967356fb97eedc45