### PR TITLE
Add unified stato steps and update pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -153,14 +153,24 @@ header nav { /* Aggiunto per allineare il bottone a destra */
 .button-logout:hover {
     background-color: rgba(255, 255, 255, 0.15);
 }
-.status-badge.status-default {
-    background-color: #17a2b8; /* Esempio colore per default (info blu/ciano) */
-    color: white;
-    font-size: 0.7em;
+.status-badge {
+    display: inline-block;
+    font-size: 0.75em;
     padding: 2px 5px;
     border-radius: 3px;
     margin-left: 5px;
+    color: #fff;
 }
+.status-badge.status-aperto { background-color: #6c757d; }
+.status-badge.status-in-lavorazione { background-color: #17a2b8; }
+.status-badge.status-attesa-firma { background-color: #ffc107; color:#000; }
+.status-badge.status-completato { background-color: #28a745; }
+.status-badge.status-consuntivato { background-color: #20c997; }
+.status-badge.status-inviato { background-color: #007bff; }
+.status-badge.status-in-attesa-accettazione { background-color: #6610f2; }
+.status-badge.status-fatturato { background-color: #e83e8c; }
+.status-badge.status-chiuso { background-color: #343a40; }
+.status-badge.status-default { background-color: #17a2b8; }
 
 .button.outline.small {
     background-color: transparent;

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -8,6 +8,7 @@ import * as XLSX from 'xlsx';
 import { Link, Navigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient'; // Assicurati che il percorso sia corretto
 import { generateFoglioAssistenzaPDF } from '../utils/pdfGenerator'; // Assicurati che il percorso sia corretto
+import { STATO_FOGLIO_STEPS } from '../utils/statoFoglio';
 
 // Questo componente ora riceve le anagrafiche principali come props da App.jsx
 // per evitare di doverle ricaricare qui. Questo migliora le performance e la consistenza.
@@ -378,11 +379,9 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
                         <label htmlFor="filtroStato">Stato Foglio:</label>
                         <select id="filtroStato" value={filtroStato} onChange={e => setFiltroStato(e.target.value)}>
                             <option value="">Tutti gli Stati</option>
-                            <option value="Aperto">Aperto</option>
-                            <option value="In Lavorazione">In Lavorazione</option>
-                            <option value="Attesa Firma">Attesa Firma</option>
-                            <option value="Completato">Completato</option>
-                            <option value="Chiuso">Chiuso</option>
+                            {STATO_FOGLIO_STEPS.map(st => (
+                                <option key={st} value={st}>{st}</option>
+                            ))}
                         </select>
                     </div>
                 </div>

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -9,6 +9,7 @@ import { supabase } from '../supabaseClient'; // Assicurati che il percorso sia 
 import InterventoAssistenzaForm from '../components/InterventoAssistenzaForm'; // Assicurati che il percorso sia corretto
 import InterventoCard from '../components/InterventoCard';
 import { generateFoglioAssistenzaPDF } from '../utils/pdfGenerator'; // Assicurati che il percorso sia corretto
+import { STATO_FOGLIO_STEPS } from '../utils/statoFoglio';
 
 function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const { foglioId } = useParams();
@@ -45,8 +46,10 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
             userRole === 'head' ||
             (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)));
 
+    const completatoIndex = STATO_FOGLIO_STEPS.indexOf('Completato');
+    const statoIndex = STATO_FOGLIO_STEPS.indexOf(foglio?.stato_foglio);
     const isChiuso = foglio?.stato_foglio === 'Chiuso';
-    const isCompletato = foglio?.stato_foglio === 'Completato';
+    const isCompletatoOrBeyond = statoIndex >= completatoIndex && completatoIndex !== -1;
     const firmaPresente = !!foglio?.firma_cliente_url;
 
     const baseEditPermission =
@@ -62,7 +65,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
         } else if (userRole === 'manager') {
             canEditThisFoglioOverall = !isChiuso;
         } else if (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)) {
-            canEditThisFoglioOverall = !isChiuso && !isCompletato && !firmaPresente;
+            canEditThisFoglioOverall = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
         }
     }
 
@@ -87,7 +90,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
         } else if (userRole === 'manager') {
             canModifyInterventi = !isChiuso;
         } else if (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)) {
-            canModifyInterventi = !isChiuso && !isCompletato && !firmaPresente;
+            canModifyInterventi = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
         }
     }
 

--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate, useParams, Link, Navigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
+import { STATO_FOGLIO_STEPS } from '../utils/statoFoglio';
 import SignatureCanvas from 'react-signature-canvas';
 import VoiceInputButton from '../components/VoiceInputButton';
 
@@ -77,8 +78,10 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
                 userRole === 'manager' ||
                 (userRole === 'user' && (formCreatoDaUserIdOriginal === currentUserId || isAssignedTecnico))));
 
+    const completatoIndex = STATO_FOGLIO_STEPS.indexOf('Completato');
+    const statoIndex = STATO_FOGLIO_STEPS.indexOf(formStatoFoglio);
     const isChiuso = formStatoFoglio === 'Chiuso';
-    const isCompletato = formStatoFoglio === 'Completato';
+    const isCompletatoOrBeyond = statoIndex >= completatoIndex && completatoIndex !== -1;
     const firmaPresente = !!firmaClientePreview;
 
     let canSubmitForm = false;
@@ -90,7 +93,7 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         } else if (userRole === 'manager') {
             canSubmitForm = !isChiuso;
         } else if (userRole === 'user' && (formCreatoDaUserIdOriginal === currentUserId || isAssignedTecnico)) {
-            canSubmitForm = !isChiuso && !isCompletato && !firmaPresente;
+            canSubmitForm = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
         }
     }
 
@@ -517,11 +520,9 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
                 <div>
                     <label htmlFor="formStatoFoglio">Stato Foglio:</label>
                     <select id="formStatoFoglio" value={formStatoFoglio} onChange={e => setFormStatoFoglio(e.target.value)}>
-                        <option value="Aperto">Aperto</option>
-                        <option value="In Lavorazione">In Lavorazione</option>
-                        <option value="Attesa Firma">Attesa Firma</option>
-                        <option value="Completato">Completato</option>
-                        <option value="Chiuso">Chiuso</option>
+                        {STATO_FOGLIO_STEPS.map(st => (
+                            <option key={st} value={st}>{st}</option>
+                        ))}
                     </select>
                 </div>
                 {error && <p style={{ color: 'red', fontWeight:'bold' }}>ERRORE: {error}</p>}

--- a/src/utils/statoFoglio.js
+++ b/src/utils/statoFoglio.js
@@ -1,0 +1,11 @@
+export const STATO_FOGLIO_STEPS = [
+  'Aperto',
+  'In Lavorazione',
+  'Attesa Firma',
+  'Completato',
+  'Consuntivato',
+  'Inviato',
+  'In attesa accettazione',
+  'Fatturato',
+  'Chiuso'
+];


### PR DESCRIPTION
## Summary
- centralize service sheet statuses in new `STATO_FOGLIO_STEPS`
- render state dropdowns from this array
- determine edit permissions using order position of states
- display status badges with colors for all states

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686805972cd8832d800cd54ff90adb73