### PR TITLE
Implement state-based edit permissions

### DIFF
--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -47,9 +47,11 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
             (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)));
 
     const completatoIndex = STATO_FOGLIO_STEPS.indexOf('Completato');
+    const chiusoIndex = STATO_FOGLIO_STEPS.indexOf('Chiuso');
     const statoIndex = STATO_FOGLIO_STEPS.indexOf(foglio?.stato_foglio);
     const isChiuso = foglio?.stato_foglio === 'Chiuso';
-    const isCompletatoOrBeyond = statoIndex >= completatoIndex && completatoIndex !== -1;
+    const isPostCompletato = completatoIndex !== -1 && statoIndex > completatoIndex;
+    const isPostChiuso = chiusoIndex !== -1 && statoIndex > chiusoIndex;
     const firmaPresente = !!foglio?.firma_cliente_url;
 
     const baseEditPermission =
@@ -60,12 +62,13 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
 
     let canEditThisFoglioOverall = false;
     if (foglio) {
-        if (userRole === 'admin') {
-            canEditThisFoglioOverall = true;
-        } else if (userRole === 'manager') {
-            canEditThisFoglioOverall = !isChiuso;
-        } else if (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)) {
-            canEditThisFoglioOverall = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
+        if (userRole === 'admin' || userRole === 'manager') {
+            canEditThisFoglioOverall = !isPostChiuso;
+        } else if (
+            userRole === 'user' &&
+            (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)
+        ) {
+            canEditThisFoglioOverall = !isPostCompletato;
         }
     }
 
@@ -85,12 +88,13 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
 
     let canModifyInterventi = false;
     if (foglio) {
-        if (userRole === 'admin') {
-            canModifyInterventi = true;
-        } else if (userRole === 'manager') {
-            canModifyInterventi = !isChiuso;
-        } else if (userRole === 'user' && (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)) {
-            canModifyInterventi = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
+        if (userRole === 'admin' || userRole === 'manager') {
+            canModifyInterventi = !isPostChiuso;
+        } else if (
+            userRole === 'user' &&
+            (foglio.creato_da_user_id === currentUserId || isUserAssignedTecnico)
+        ) {
+            canModifyInterventi = !isPostCompletato;
         }
     }
 

--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -82,23 +82,26 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
     const completatoIndex = STATO_FOGLIO_STEPS.indexOf('Completato');
     const attesaFirmaIndex = STATO_FOGLIO_STEPS.indexOf('Attesa Firma');
     const consuntivatoIndex = STATO_FOGLIO_STEPS.indexOf('Consuntivato');
+    const chiusoIndex = STATO_FOGLIO_STEPS.indexOf('Chiuso');
     const statoIndex = STATO_FOGLIO_STEPS.indexOf(formStatoFoglio);
     const showNotaStato = attesaFirmaIndex !== -1 && statoIndex >= attesaFirmaIndex;
     const notaStatoRequired = consuntivatoIndex !== -1 && statoIndex >= consuntivatoIndex;
     const isChiuso = formStatoFoglio === 'Chiuso';
-    const isCompletatoOrBeyond = statoIndex >= completatoIndex && completatoIndex !== -1;
+    const isPostCompletato = completatoIndex !== -1 && statoIndex > completatoIndex;
+    const isPostChiuso = chiusoIndex !== -1 && statoIndex > chiusoIndex;
     const firmaPresente = !!firmaClientePreview;
 
     let canSubmitForm = false;
     if (!isEditMode) {
         canSubmitForm = baseFormPermission;
     } else if (baseFormPermission) {
-        if (userRole === 'admin') {
-            canSubmitForm = true;
-        } else if (userRole === 'manager') {
-            canSubmitForm = !isChiuso;
-        } else if (userRole === 'user' && (formCreatoDaUserIdOriginal === currentUserId || isAssignedTecnico)) {
-            canSubmitForm = !isChiuso && !isCompletatoOrBeyond && !firmaPresente;
+        if (userRole === 'admin' || userRole === 'manager') {
+            canSubmitForm = !isPostChiuso;
+        } else if (
+            userRole === 'user' &&
+            (formCreatoDaUserIdOriginal === currentUserId || isAssignedTecnico)
+        ) {
+            canSubmitForm = !isPostCompletato;
         }
     }
 
@@ -260,6 +263,11 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         if (!formSelectedClienteId) { setError("Cliente obbligatorio."); setLoadingSubmit(false); return; }
         if (indirizziClienteSelezionato.length > 0 && !formSelectedIndirizzoId) {
             setError("Selezionare un indirizzo di intervento."); setLoadingSubmit(false); return;
+        }
+        if (notaStatoRequired && !formNotaStatoFoglio.trim()) {
+            setError("Nota Stato obbligatoria.");
+            setLoadingSubmit(false);
+            return;
         }
 
         try {


### PR DESCRIPTION
## Summary
- compute `isPostCompletato` based on `STATO_FOGLIO_STEPS`
- restrict edit permissions: users can edit only until `Completato`; managers and admins until `Chiuso`
- enforce required state for note field during submission

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686808ab9ff8832dbccb1f8c03614c65