### PR TITLE
Update version injection to import package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## Versioning
 
-L'applicazione visualizza la versione corrente e una breve descrizione nella dashboard. Il numero di versione e la descrizione sono letti dai campi `version` e `description` di `package.json` ed sono disponibili come costanti `__APP_VERSION__` e `__APP_DESCRIPTION__` durante la build Vite.
+L'applicazione visualizza la versione corrente e una breve descrizione nella dashboard. In `vite.config.js` questi valori vengono importati direttamente da `package.json` (`import pkg from './package.json' assert { type: 'json' };`) e resi disponibili come costanti `__APP_VERSION__` e `__APP_DESCRIPTION__` durante la build Vite.
 
 ## Database migrations
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import pkg from './package.json' assert { type: 'json' }
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
-    __APP_DESCRIPTION__: JSON.stringify(process.env.npm_package_description),
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_DESCRIPTION__: JSON.stringify(pkg.description),
   },
 })


### PR DESCRIPTION
## Summary
- load package.json in vite.config.js using ESM JSON import
- use pkg fields for `__APP_VERSION__` and `__APP_DESCRIPTION__`
- document the direct import in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f131b038832d93bd532aec0476a6