### PR TITLE
Add codes to client usage export

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ L'applicazione visualizza la versione corrente e una breve descrizione nella das
 - Technicians must have a `user_id` linked to `public.profiles` to be selectable when compiling a service sheet.
 - `53. Alter tecnici add user_id.sql` creates a `user_id` field in `tecnici` referencing `public.profiles`.
 - `54. Alter interventi_assistenza add numero_tecnici.sql` adds a `numero_tecnici` column to `interventi_assistenza` with default 1.
+- The client registry now includes a button to export an Excel report of clients referenced in service sheets, orders or job orders. The exported spreadsheet lists the code of each sheet, order or job order in a dedicated column.


### PR DESCRIPTION
## Summary
- include code column in clients usage spreadsheet
- document new information in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870e09a41e0832d8d12de84aee12abf