### PR TITLE
Fix clienti usage export address

### DIFF
--- a/src/components/anagrafiche/ClientiManager.jsx
+++ b/src/components/anagrafiche/ClientiManager.jsx
@@ -350,7 +350,9 @@ function ClientiManager({ session }) {
 
             const { data: fogliData, error: fogliErr } = await supabase
                 .from('fogli_assistenza')
-                .select('id, cliente_id, numero_foglio');
+                .select(
+                    'id, cliente_id, numero_foglio, indirizzi_clienti!indirizzo_intervento_id (indirizzo_completo, descrizione)'
+                );
             if (fogliErr) throw fogliErr;
             const { data: ordiniData, error: ordiniErr } = await supabase
                 .from('ordini_cliente')
@@ -375,9 +377,15 @@ function ClientiManager({ session }) {
             (fogliData || []).forEach(f => {
                 const info = clientiMap.get(f.cliente_id);
                 if (info) {
+                    let sede = info.indirizzo;
+                    if (f.indirizzi_clienti && f.indirizzi_clienti.indirizzo_completo) {
+                        sede = f.indirizzi_clienti.descrizione
+                            ? `${f.indirizzi_clienti.descrizione}: ${f.indirizzi_clienti.indirizzo_completo}`
+                            : f.indirizzi_clienti.indirizzo_completo;
+                    }
                     rows.push({
                         nome_cliente: info.nome,
-                        sede_cliente: info.indirizzo,
+                        sede_cliente: sede,
                         origine: 'Foglio di lavoro',
                         codice: f.numero_foglio || f.id.substring(0, 8)
                     });


### PR DESCRIPTION
## Summary
- include `indirizzo_intervento_id` join when exporting client usage
- when exporting usage for worksheets, use the specific address from each worksheet instead of always the default client address

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6871041ef388832db37427baa9910958