### PR TITLE
Adjust hooks to ignore session refreshes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ function App() {
   useEffect(() => {
     sessionRef.current = session;
     // console.log("APP.JSX: sessionRef aggiornato. Nuovo ruolo in ref:", sessionRef.current?.user?.role);
-  }, [session]);
+  }, [session?.user?.id]);
 
   // useEffect per la sessione
   useEffect(() => {
@@ -217,7 +217,7 @@ function App() {
       }
     };
     fetchCommonData();
-  }, [session]); 
+  }, [session?.user?.id]);
 
   // useEffect per Page Visibility API
   useEffect(() => { 

--- a/src/components/anagrafiche/ClientiManager.jsx
+++ b/src/components/anagrafiche/ClientiManager.jsx
@@ -74,7 +74,7 @@ function ClientiManager({ session }) {
     useEffect(() => {
         setClienti([]);
         setPageLoading(false);
-    }, [session, canManage]);
+    }, [session?.user?.id, canManage]);
     useEffect(() => {
         const fetchIndirizzi = async () => {
             if (selectedCliente?.id) {

--- a/src/components/anagrafiche/TecniciManager.jsx
+++ b/src/components/anagrafiche/TecniciManager.jsx
@@ -73,7 +73,7 @@ function TecniciManager({ session }) {
     useEffect(() => {
         setTecnici([]);
         setPageLoading(false);
-    }, [session, canManage]);
+    }, [session?.user?.id, canManage]);
 
     useEffect(() => {
         if (!canManage) return;

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -111,7 +111,7 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
             setFogli(processedFogli);
         }
         setLoadingFogli(false);
-    }, [session, loadingAnagrafiche, userRole, currentUserId, filtroDataDa, filtroDataA, allClienti, allCommesse, allOrdini, allTecnici]); 
+    }, [loadingAnagrafiche, userRole, currentUserId, filtroDataDa, filtroDataA, allClienti, allCommesse, allOrdini, allTecnici]);
 
     // useEffect per il fetch con debounce (per i filtri data)
     useEffect(() => {

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -145,7 +145,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
           setInterventi(interventiData || []); 
         }
         setLoadingPage(false);
-    }, [foglioId, session]);
+    }, [foglioId, currentUserId]);
 
     useEffect(() => {
         fetchFoglioData();

--- a/src/pages/FoglioAssistenzaFormPage.jsx
+++ b/src/pages/FoglioAssistenzaFormPage.jsx
@@ -241,7 +241,7 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
         } else if (!isEditMode) {
             setPageLoading(false);
         }
-    }, [isEditMode, foglioIdParam, session]);
+    }, [isEditMode, foglioIdParam, currentUserId]);
 
     useEffect(() => {
         const checkTecnico = async () => {
@@ -258,7 +258,7 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
             }
         };
         checkTecnico();
-    }, [isEditMode, foglioIdParam, session, currentUserEmail, formAssignedTecnicoId, currentUserId]);
+    }, [isEditMode, foglioIdParam, currentUserEmail, formAssignedTecnicoId, currentUserId]);
 
     useEffect(() => {
         const fetchTecnici = async () => {
@@ -267,7 +267,7 @@ const [formStatoFoglio, setFormStatoFoglio] = useState('Aperto');
             else console.error('Errore fetch tecnici:', error);
         };
         fetchTecnici();
-    }, [session]);
+    }, [currentUserId]);
 
     const handleClienteFile = (e) => {
         const file = e.target.files && e.target.files[0];


### PR DESCRIPTION
## Summary
- avoid reruns of anagrafiche load when token refreshes
- fetch list data without including session in dependencies
- limit form data hooks to user id changes
- update detail view fetch hook
- reset anagrafiche managers only when user id changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68716c4fb9cc832db5c5f6f89499ffce