### PR TITLE
Add client filtering for job orders and orders

### DIFF
--- a/src/components/anagrafiche/OrdiniClienteManager.jsx
+++ b/src/components/anagrafiche/OrdiniClienteManager.jsx
@@ -3,7 +3,7 @@
  * and job orders. Includes pagination, import/export and CRUD features
  * via Supabase. Visibility depends on user role.
  */
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { supabase } from '../../supabaseClient';
 import Papa from 'papaparse';
 import * as XLSX from 'xlsx';
@@ -26,7 +26,8 @@ function OrdiniClienteManager({ session, clienti, commesse }) {
     const [formDescrizioneOrdine, setFormDescrizioneOrdine] = useState('');
     const [formSelectedClienteIdOrdine, setFormSelectedClienteIdOrdine] = useState('');
     const [formSelectedCommessaIdOrdine, setFormSelectedCommessaIdOrdine] = useState('');
-    const [editingOrdine, setEditingOrdine] = useState(null); 
+    const [editingOrdine, setEditingOrdine] = useState(null);
+    const [filtroCliente, setFiltroCliente] = useState('');
 
     // Stati per la PAGINAZIONE
     const [currentPage, setCurrentPage] = useState(1);
@@ -45,6 +46,15 @@ function OrdiniClienteManager({ session, clienti, commesse }) {
     // Ref per input file e debounce
     const fileInputRef = useRef(null);
     const debounceTimeoutRef = useRef(null);
+
+    const clientiOrdinati = useMemo(
+        () => [...(clienti || [])].sort((a, b) => a.nome_azienda.localeCompare(b.nome_azienda)),
+        [clienti]
+    );
+    const clientiFiltrati = useMemo(
+        () => clientiOrdinati.filter(c => c.nome_azienda.toLowerCase().includes(filtroCliente.toLowerCase())),
+        [clientiOrdinati, filtroCliente]
+    );
 
     // --- FUNZIONI ---
 
@@ -437,7 +447,26 @@ function OrdiniClienteManager({ session, clienti, commesse }) {
             {canManage && (
                 <form onSubmit={handleSubmitForm} style={{ marginBottom: '20px', padding: '15px', border: '1px solid #eee', borderRadius: '5px' }}>
                     <h3>{editingOrdine ? 'Modifica Ordine Cliente' : 'Nuovo Ordine Cliente'}</h3>
-                    <div> <label htmlFor="formClienteOrdine">Cliente Associato (Obbligatorio):</label> <select id="formClienteOrdine" value={formSelectedClienteIdOrdine} onChange={e => { setFormSelectedClienteIdOrdine(e.target.value); setFormSelectedCommessaIdOrdine(''); }} required> <option value="">Seleziona Cliente</option> {(clienti || []).map(c => <option key={c.id} value={c.id}>{c.nome_azienda}</option>)} </select> </div>
+                    <div> <label htmlFor="formClienteOrdine">Cliente Associato (Obbligatorio):</label>
+                        <input
+                            type="text"
+                            placeholder="Filtra cliente..."
+                            value={filtroCliente}
+                            onChange={e => setFiltroCliente(e.target.value)}
+                            style={{ marginBottom: '5px', width: 'calc(100% - 22px)' }}
+                        />
+                        <select
+                            id="formClienteOrdine"
+                            value={formSelectedClienteIdOrdine}
+                            onChange={e => { setFormSelectedClienteIdOrdine(e.target.value); setFormSelectedCommessaIdOrdine(''); setFiltroCliente(''); }}
+                            required
+                        >
+                            <option value="">Seleziona Cliente ({clientiFiltrati.length})</option>
+                            {clientiFiltrati.map(c => (
+                                <option key={c.id} value={c.id}>{c.nome_azienda}</option>
+                            ))}
+                        </select>
+                    </div>
                     <div> <label htmlFor="formNumeroOrdine">Numero Ordine Cliente:</label> <input type="text" id="formNumeroOrdine" value={formNumeroOrdine} onChange={e => setFormNumeroOrdine(e.target.value)} required /> </div>
                     <div> <label htmlFor="formDataOrdine">Data Ordine:</label> <input type="date" id="formDataOrdine" value={formDataOrdine} onChange={e => setFormDataOrdine(e.target.value)} /> </div>
                     <div> <label htmlFor="formDescrizioneOrdine">Descrizione Ordine:</label> <input type="text" id="formDescrizioneOrdine" value={formDescrizioneOrdine} onChange={e => setFormDescrizioneOrdine(e.target.value)} /> </div>


### PR DESCRIPTION
## Summary
- add `useMemo` filtering logic for clients in `CommesseManager`
- show input box to filter clients when editing/creating a job order
- add the same filter input for clients in `OrdiniClienteManager`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: blocked internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687204ffb32c832daa8b56cc6f4b9852