### PR TITLE
Allow duplicated order codes across different clients

### DIFF
--- a/database query/40. Vincoli UNIQUE.sql
+++ b/database query/40. Vincoli UNIQUE.sql
@@ -6,17 +6,14 @@ ADD CONSTRAINT clienti_nome_azienda_unique UNIQUE (nome_azienda);
 ALTER TABLE public.commesse
 ADD CONSTRAINT commesse_codice_commessa_unique UNIQUE (codice_commessa);
 
--- Per ordini_cliente (numero_ordine_cliente)
--- Assicurati che non ci siano duplicati prima di aggiungere il vincolo,
--- altrimenti dovrai decidere come gestirli.
--- Potresti voler rendere numero_ordine_cliente univoco PER cliente_id,
--- il che è più complesso (indice univoco su più colonne).
--- Per ora, lo rendiamo globalmente univoco per semplicità, ma valuta se è corretto.
--- Se deve essere univoco per cliente, la logica di upsert diventa più complessa
--- perché onConflict su una singola colonna potrebbe non bastare.
--- Per questo esempio, assumiamo che numero_ordine_cliente sia globalmente univoco.
+-- Per ordini_cliente (numero_ordine_cliente, cliente_id)
+-- L'unicità va garantita dalla combinazione del codice ordine con il cliente
+-- in modo da permettere lo stesso numero per clienti differenti.
 ALTER TABLE public.ordini_cliente
-ADD CONSTRAINT ordini_cliente_numero_ordine_cliente_unique UNIQUE (numero_ordine_cliente);
+    DROP CONSTRAINT IF EXISTS ordini_cliente_numero_ordine_cliente_unique;
+ALTER TABLE public.ordini_cliente
+    ADD CONSTRAINT ordini_cliente_numero_ordine_cliente_unique
+        UNIQUE (numero_ordine_cliente, cliente_id);
 
 -- Per tecnici (combinazione di nome e cognome)
 -- Creiamo un indice univoco su entrambe le colonne.

--- a/src/components/anagrafiche/OrdiniClienteManager.jsx
+++ b/src/components/anagrafiche/OrdiniClienteManager.jsx
@@ -372,7 +372,10 @@ function OrdiniClienteManager({ session, clienti, commesse }) {
 
                 if (ordiniPerUpsert.length > 0) {
                     console.log("Ordini pronti per upsert finale:", ordiniPerUpsert);
-                    const { data, error: upsertError } = await supabase.from('ordini_cliente').upsert(ordiniPerUpsert, { onConflict: 'numero_ordine_cliente' }).select();
+                    const { data, error: upsertError } = await supabase
+                        .from('ordini_cliente')
+                        .upsert(ordiniPerUpsert, { onConflict: 'numero_ordine_cliente,cliente_id' })
+                        .select();
                     if (upsertError) { errorsDetail.push(`Errore generale durante l'upsert degli ordini: ${upsertError.message}`); errorCount += ordiniPerUpsert.length - (data ? data.length : 0); console.error("Err upsert ordini:", upsertError); }
                     successCount = data ? data.length : 0;
                 }


### PR DESCRIPTION
## Summary
- enforce uniqueness of `numero_ordine_cliente` per `cliente_id`
- update bulk order import to use the new composite key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687208ccb640832d9ee98296dbfa20f8