### PR TITLE
Add Oilsafe logo to dashboard

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -3,14 +3,16 @@
  * using session data provided by `App.jsx`.
  */
 import React from 'react';
+import oilsafeLogo from '../assets/oilsafe-logo.png';
 
 // Componente per la pagina Dashboard.
 // Ora è una semplice pagina di benvenuto, ripulita dalla funzionalità di test del PDF.
 function DashboardPage({ session }) { // Riceve la sessione per personalizzare il saluto
   return (
     <div>
-      <h2>Dashboard</h2>
-      <p>Benvenuto in Oilsafe Service Hub!</p>
+        <h2>Dashboard</h2>
+        <img src={oilsafeLogo} alt="Oilsafe Service Hub logo" style={{ maxWidth: '250px', height: 'auto' }} />
+        <p>Benvenuto in Oilsafe Service Hub!</p>
       {/* Mostra un messaggio di benvenuto personalizzato se la sessione utente è attiva */}
       {session &&
         <p>


### PR DESCRIPTION
## Summary
- display company logo on the dashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874d0b62874832d939bd92bd4f42b04