### PR TITLE
Lista fogli di lavoro migliorata

### DIFF
--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -23,6 +23,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
     const [editingIntervento, setEditingIntervento] = useState(null);
     const [interventoFormReadOnly, setInterventoFormReadOnly] = useState(false);
     const [stampaSingolaLoading, setStampaSingolaLoading] = useState(false);
+    const [sendingEmail, setSendingEmail] = useState(false);
     // Il layout di stampa predefinito diventa quello dettagliato
     const [layoutStampa, setLayoutStampa] = useState('detailed');
     const [isSmallScreen, setIsSmallScreen] = useState(false);
@@ -272,6 +273,20 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
         setStampaSingolaLoading(false);
     };
 
+    const handleSendEmail = async () => {
+        if (!window.confirm('Inviare il report di questo foglio via email?')) return;
+        setSendingEmail(true);
+        setError(null);
+        const { error: fnError } = await supabase.functions.invoke('invia-report-foglio', { body: { foglio_id: foglioId } });
+        if (fnError) {
+            console.error('Errore invio email:', fnError);
+            setError(fnError.message || 'Errore invio email');
+        } else {
+            alert('Email inviata.');
+        }
+        setSendingEmail(false);
+    };
+
     if (loadingPage) return <p>Caricamento dati foglio di assistenza...</p>;
     if (error && !foglio) return <p style={{ color: 'red', fontWeight:'bold' }}>ERRORE: {error}</p>;
     if (!session) return <Navigate to="/login" replace />;
@@ -294,6 +309,15 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                             disabled={stampaSingolaLoading || !foglio || actionLoading}
                         >
                             {stampaSingolaLoading ? 'Stampa in corso...' : 'Stampa Foglio'}
+                        </button>
+                    )}
+                    {canViewThisFoglio && (
+                        <button
+                            onClick={handleSendEmail}
+                            className="button secondary"
+                            disabled={sendingEmail || actionLoading}
+                        >
+                            {sendingEmail ? 'Invio...' : 'Invia Email'}
                         </button>
                     )}
                     {canEditThisFoglioOverall && (


### PR DESCRIPTION
## Summary
- riorganizza la tabella dei fogli di assistenza spostando la colonna **Azioni** prima di **N. Foglio**
- mostra il **Motivo Intervento** in elenco con testo troncato
- rimuove il pulsante *Invia Email* dalla lista
- aggiunge il pulsante *Invia Email* nel dettaglio del foglio

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68825313404c832da9dd9e4dfa3ae452