### PR TITLE
feat: style header based on database label

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@ html, body {
     overflow-x: auto;
 }
 .app-container { display: flex; flex-direction: column; min-height: 100vh; }
-header { background-color: #003366; color: white; padding: 1rem; }
+header { color: white; padding: 1rem; }
 header h1 { margin: 0; font-size: 1.5rem; }
 nav a { color: white; margin-right: 1rem; text-decoration: none; }
 nav a:hover { text-decoration: underline; }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,14 @@ function ProtectedRoute({ session }) {
 }
 
 function App() {
+  const dbLabel = import.meta.env.VITE_SUPABASE_DB_LABEL;
+  const headerBgColor =
+    dbLabel === 'Oilsafe-Assistenza_main'
+      ? '#003366'
+      : dbLabel === 'Oilsafe-Assistenza_Debug'
+        ? 'red'
+        : undefined;
+
   const [session, setSession] = useState(null);
   const [loadingSession, setLoadingSession] = useState(true);
   const navigate = useNavigate();
@@ -270,7 +278,7 @@ function App() {
 
   return (
     <div className="app-container">
-      <header>
+      <header style={{ backgroundColor: headerBgColor }}>
         <h1>Oilsafe Service Hub ver.{__APP_VERSION__}</h1>
         {session && session.user && (
           <nav>


### PR DESCRIPTION
## Summary
- derive header color from VITE_SUPABASE_DB_LABEL environment variable
- drop static header background rule in App.css

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 31 problems (24 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6894daacccd8832d8bcaf2f518c66450