### PR TITLE
feat: Sistema Expand/Collapse per Filtri Elenco Fogli di Assistenza

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Tutte le modifiche significative al progetto sono documentate in questo file.
 
 Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.0.0/),
 e questo progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
+## [1.1.14] - 2025-12-14
+
+### Added
+- Expande \ Collapse filtri in pagina elenco fogli di assistenza 
+
 ## [1.1.13] - 2025-12-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "oilsafe-service-frontend",
   "private": true,
-  "version": "1.1.13",
-  "description": "Inserita azione di copia cartella archiviazione report negli appunti",
+  "version": "1.1.14",
+  "description": "Expande - Collapse filtri in pagina elenco fogli di assistenza",
   "author": "Massimo Centrella",
   "company": "Oilsafe S.r.l.",
   "type": "module",

--- a/src/App.css
+++ b/src/App.css
@@ -605,6 +605,22 @@ label:has(> input[type="radio"]) {
     }
 }
 
+/* Hover effect per toggle button filtri */
+.filtri-container .expand-button:hover {
+    background-color: rgba(0, 51, 102, 0.05);
+    border-radius: 4px;
+}
+
+/* Animazione pulse per badge filtri attivi */
+@keyframes badgePulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+
+.filtri-container h4 span {
+    animation: badgePulse 2s ease-in-out infinite;
+}
+
 /* ========================================
    TABLET & iPAD BREAKPOINT (768px)
    ======================================== */


### PR DESCRIPTION
## 📋 Sommario

Implementato sistema di espansione/collasso per la sezione "Filtri di Ricerca" nella pagina **Elenco Fogli di Assistenza** per ottimizzare lo spazio sullo schermo mantenendo sempre visibili i controlli di paginazione.

## ✨ Funzionalità Implementate

### 🎯 Header Filtri (Sempre Visibile)
- **Toggle button** con icona ▶ (collapsed) / ▼ (expanded)
- **Badge numerico** che mostra il conteggio dei filtri attivi (es: "Filtri di Ricerca (3)")
- **Pulsante "Azzera Filtri"** sempre accessibile anche quando collapsed

### 📊 Sommario Filtri Attivi (Visibile solo quando Collapsed)
- Mostra elenco descrittivo dei filtri attivi con i loro valori
- Esempio: `3 filtri attivi: Cliente (Acme Corp) • Data (01/12 - 15/12) • Stato (Aperto)`
- Messaggio "Nessun filtro attivo" quando non ci sono filtri applicati
- Troncamento automatico a 20 caratteri per valori lunghi con "..."

### 🔽 Sezione Collapsible
- Grid responsive 4 colonne (2 col tablet, 1 col mobile)
- Tutti gli 8 campi filtro + checkbox "Mostra solo fogli da stampare"
- Animazione slide down/up fluida

### 📄 Controlli Paginazione (Sempre Visibili)
- Input "Max fogli", pulsanti navigazione pagine, contatore totale
- Sempre accessibili indipendentemente dallo stato dei filtri

## 🎨 Caratteristiche

✅ **Persistenza**: localStorage  
✅ **Accessibilità**: ARIA, tastiera (Enter/Space), WCAG AA  
✅ **Responsive**: Desktop/tablet/mobile  
✅ **Feedback Visivo**: Auto-espansione dopo reset filtri  
✅ **Performance**: useCallback optimization  

## 📁 File Modificati

- `src/pages/FogliAssistenzaListPage.jsx` (+328, -107)
- `src/App.css` (+16)
- `package.json` (v1.1.14)
- `CHANGELOG.md`

## 🧪 Testing

- [x] Funzionalità expand/collapse
- [x] localStorage persistenza
- [x] Badge e sommario filtri attivi
- [x] Responsive (desktop/tablet/mobile)
- [x] Accessibilità (ARIA, tastiera)
- [x] Build produzione OK
- [x] ESLint passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)