### PR TITLE
fix: Correggi spazi mancanti nel PDF e preview bianca su Chrome (v1.1.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Tutte le modifiche significative al progetto sono documentate in questo file.
 
 Il formato si basa su [Keep a Changelog](https://keepachangelog.com/it/1.0.0/),
 e questo progetto aderisce al [Semantic Versioning](https://semver.org/lang/it/).
+## [1.1.17] - 2026-03-28
+
+### Added
+- Fix spazi mancanti nel PDF: i viewer PDF ignorano gli spazi finali nei blocchi BT...ET
+  separati generati da jsPDF; risolto spostando gli spazi come prefisso del segmento
+  successivo e concatenando segmenti dello stesso stile in un'unica chiamata doc.text()
+- Fix anteprima PDF bianca su Chrome: convertita la data URL Base64 in Blob URL prima
+  di assegnarla all'iframe (Chrome non carica data URL >~2MB negli iframe)
+
 ## [1.1.16] - 2025-12-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ This is a React SPA for service management at Oilsafe S.r.l., built with Vite an
 - Voice input support for intervention forms
 - Excel export functionality for client reports
 - Signature capture for service completion
+- Company price list for standard activities
+- Customer price list overview with expand/collapse table
+
+### PDF Generation Notes
+- Three layouts: `table`, `detailed` (default), `detailed_with_costs` (admin only)
+- Markdown formatting supported in descriptions: `**bold**`, `*italic*`, `***bolditalic***` — parsed by `utils/textFormatter.js`
+- **Preview mode**: `generateFoglioAssistenzaPDF(..., { preview: true })` returns a data URL string. Always convert to a **Blob URL** via `URL.createObjectURL()` before assigning to an `<iframe src>` — Chrome cannot load large data URLs (>~2MB) in iframes. Revoke the Blob URL with `URL.revokeObjectURL()` on modal close.
+- **Word-wrap in descriptions**: The `addFormattedTextWithMarkdown` function handles multi-segment styled text with manual word-wrap. Each word carries its trailing space to avoid blank leading tokens after line breaks.
 
 ### Component Structure
 - **Pages**: Top-level route components handling data fetching and page layout

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "oilsafe-service-frontend",
   "private": true,
-  "version": "1.1.16",
-  "description": "Overview listini prezzi clienti con expand/collapse",
+  "version": "1.1.17",
+  "description": "Fix spazi mancanti nel PDF e preview bianca su Chrome",
   "author": "Massimo Centrella",
   "company": "Oilsafe S.r.l.",
   "type": "module",

--- a/src/pages/FogliAssistenzaListPage.jsx
+++ b/src/pages/FogliAssistenzaListPage.jsx
@@ -542,7 +542,15 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
             // Genera PDF in modalità preview (ritorna DataURL invece di salvare)
             const pdfDataUrl = await generateFoglioAssistenzaPDF(foglioData, interventiData || [], attivitaPreviste || [], { layout: layoutStampa, preview: true });
 
-            setPreviewPdfUrl(pdfDataUrl);
+            // Converti data URL in Blob URL: Chrome non carica data URL grandi negli iframe
+            const base64 = pdfDataUrl.split(',')[1];
+            const binary = atob(base64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            const blob = new Blob([bytes], { type: 'application/pdf' });
+            const blobUrl = URL.createObjectURL(blob);
+
+            setPreviewPdfUrl(blobUrl);
             setShowPreview(true);
         } catch (err) {
             console.error(`Errore durante la generazione della preview per il foglio ${foglioId}:`, err);
@@ -1298,6 +1306,7 @@ function FogliAssistenzaListPage({ session, loadingAnagrafiche, clienti: allClie
                             </button>
                             <button
                                 onClick={() => {
+                                    if (previewPdfUrl) URL.revokeObjectURL(previewPdfUrl);
                                     setShowPreview(false);
                                     setPreviewPdfUrl(null);
                                 }}

--- a/src/pages/FoglioAssistenzaDetailPage.jsx
+++ b/src/pages/FoglioAssistenzaDetailPage.jsx
@@ -693,7 +693,15 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                 { layout: layoutStampa, preview: true }
             );
 
-            setPreviewPdfUrl(pdfDataUrl);
+            // Converti data URL in Blob URL: Chrome non carica data URL grandi negli iframe
+            const base64 = pdfDataUrl.split(',')[1];
+            const binary = atob(base64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            const blob = new Blob([bytes], { type: 'application/pdf' });
+            const blobUrl = URL.createObjectURL(blob);
+
+            setPreviewPdfUrl(blobUrl);
             setShowPreview(true);
         } catch (err) {
             console.error(`Errore durante la generazione dell'anteprima PDF per il foglio singolo ${foglioId}:`, err);
@@ -1230,6 +1238,7 @@ function FoglioAssistenzaDetailPage({ session, tecnici }) {
                             </button>
                             <button
                                 onClick={() => {
+                                    if (previewPdfUrl) URL.revokeObjectURL(previewPdfUrl);
                                     setShowPreview(false);
                                     setPreviewPdfUrl(null);
                                 }}

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -124,9 +124,35 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, at
     };
 
     // Renderizza una singola linea di testo con stili misti (grassetto, corsivo, ecc.)
+    // Regole:
+    // 1. Segmenti contigui con lo stesso stile vengono concatenati in un'unica chiamata doc.text()
+    //    (i viewer PDF ignorano gli spazi finali nei blocchi BT...ET separati).
+    // 2. Lo spazio finale di un segmento che precede un cambio stile viene spostato come
+    //    prefisso del segmento successivo, così non viene mai a fine blocco BT...ET.
     const renderLineWithStyles = (currentDoc, lineSegments, x, y) => {
+        // Step 1: sposta gli spazi finali come prefisso del segmento successivo
+        const rebalanced = lineSegments.map((seg, idx) => ({ ...seg }));
+        for (let i = 0; i < rebalanced.length - 1; i++) {
+            const trailingSpaces = rebalanced[i].text.match(/ +$/);
+            if (trailingSpaces) {
+                rebalanced[i] = { ...rebalanced[i], text: rebalanced[i].text.replace(/ +$/, '') };
+                rebalanced[i + 1] = { ...rebalanced[i + 1], text: trailingSpaces[0] + rebalanced[i + 1].text };
+            }
+        }
+
+        // Step 2: unisce segmenti contigui con lo stesso stile in un'unica stringa
+        const merged = [];
+        rebalanced.forEach(seg => {
+            if (seg.text === '') return; // salta segmenti vuoti dopo lo spostamento spazi
+            if (merged.length > 0 && merged[merged.length - 1].style === seg.style) {
+                merged[merged.length - 1] = { text: merged[merged.length - 1].text + seg.text, style: seg.style };
+            } else {
+                merged.push({ text: seg.text, style: seg.style });
+            }
+        });
+
         let currentX = x;
-        lineSegments.forEach(seg => {
+        merged.forEach(seg => {
             currentDoc.setFont(undefined, seg.style);
             currentDoc.text(seg.text, currentX, y);
             currentX += currentDoc.getTextWidth(seg.text);

--- a/src/utils/pdfGenerator.js
+++ b/src/utils/pdfGenerator.js
@@ -133,6 +133,15 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, at
         });
     };
 
+    // Rimuove lo spazio finale dall'ultimo segmento di una riga (evita rientri dopo word-wrap)
+    const trimTrailingSpace = (lineSegments) => {
+        if (lineSegments.length === 0) return lineSegments;
+        const last = lineSegments[lineSegments.length - 1];
+        const trimmed = last.text.replace(/ +$/, '');
+        if (trimmed === last.text) return lineSegments;
+        return [...lineSegments.slice(0, -1), { text: trimmed, style: last.style }];
+    };
+
     // Aggiunge testo formattato con supporto markdown (grassetto, corsivo)
     const addFormattedTextWithMarkdown = (currentDoc, text, x, maxWidth) => {
         if (!text || String(text).trim() === '') {
@@ -148,7 +157,7 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, at
         const lineHeight = fontSize / 2.83465 * 1.2;
 
         // Processa ogni riga separatamente
-        lines.forEach((line, lineIndex) => {
+        lines.forEach((line) => {
             // Se la riga è vuota, aggiungi solo uno spazio verticale
             if (line.trim() === '') {
                 checkAndAddPage(currentDoc, lineHeight);
@@ -163,33 +172,42 @@ export const generateFoglioAssistenzaPDF = async (foglioData, interventiData, at
             let currentLineWidth = 0;
 
             segments.forEach(segment => {
-                // IMPORTANTE: Splitta solo su spazi e tab, NON su newline
-                const words = segment.text.split(/( +|\t+)/);
+                // Splitta sugli spazi senza parentesi catturanti: ogni parola porta
+                // lo spazio SUCCESSIVO come trailing, così gli spazi non diventano
+                // token separati che causano rientri errati al word-wrap.
+                const words = segment.text.split(' ');
 
-                words.forEach((word) => {
-                    if (!word) return; // Skip empty strings
+                words.forEach((word, wordIndex) => {
+                    if (!word && wordIndex === 0) return; // skip empty da spazio iniziale
+
+                    // Ogni parola porta lo spazio finale tranne l'ultima del segmento
+                    const wordWithSpace = wordIndex < words.length - 1 ? word + ' ' : word;
 
                     currentDoc.setFont(undefined, segment.style);
-                    const wordWidth = currentDoc.getTextWidth(word);
+                    const wordWidth = currentDoc.getTextWidth(wordWithSpace);
 
                     // Se la parola non entra nella linea corrente, stampa la linea e vai a capo
                     if (currentLineWidth + wordWidth > maxWidth && currentLine.length > 0) {
                         checkAndAddPage(currentDoc, lineHeight);
-                        renderLineWithStyles(currentDoc, currentLine, x, yPosition);
+                        renderLineWithStyles(currentDoc, trimTrailingSpace(currentLine), x, yPosition);
                         yPosition += lineHeight;
                         currentLine = [];
                         currentLineWidth = 0;
+                        // La parola va sulla nuova riga senza spazio iniziale
+                        const wordClean = wordIndex < words.length - 1 ? word + ' ' : word;
+                        currentLine.push({ text: wordClean, style: segment.style });
+                        currentLineWidth = currentDoc.getTextWidth(wordClean);
+                    } else {
+                        currentLine.push({ text: wordWithSpace, style: segment.style });
+                        currentLineWidth += wordWidth;
                     }
-
-                    currentLine.push({ text: word, style: segment.style });
-                    currentLineWidth += wordWidth;
                 });
             });
 
             // Stampa l'ultima linea di questa riga logica
             if (currentLine.length > 0) {
                 checkAndAddPage(currentDoc, lineHeight);
-                renderLineWithStyles(currentDoc, currentLine, x, yPosition);
+                renderLineWithStyles(currentDoc, trimTrailingSpace(currentLine), x, yPosition);
                 yPosition += lineHeight;
             }
         });


### PR DESCRIPTION
## Summary
- **Fix spazi mancanti nel PDF**: i viewer PDF (Chrome, Acrobat) ignorano gli spazi finali nei blocchi `BT...ET` separati che jsPDF genera per ogni `doc.text()`. Risolto in `renderLineWithStyles` spostando gli spazi finali come prefisso del segmento successivo e concatenando segmenti dello stesso stile in un'unica chiamata `doc.text()`.
- **Fix anteprima PDF bianca su Chrome**: la data URL Base64 prodotta da jsPDF supera il limite di ~2MB che Chrome accetta negli `<iframe>`. Convertita in Blob URL tramite `URL.createObjectURL()` in `FoglioAssistenzaDetailPage` e `FogliAssistenzaListPage`; il Blob URL viene revocato alla chiusura del modal.
- **CLAUDE.md**: aggiornata documentazione con note su PDF generation e Blob URL.

## Test plan
- [ ] Aprire un foglio con descrizioni lunghe → Stampa PDF (layout Dettagliato) → verificare che gli spazi tra parole siano presenti
- [ ] Aprire un foglio con molti interventi → Anteprima PDF su Chrome → verificare che il PDF sia visibile nell'iframe
- [ ] Dal modal anteprima → cliccare Stampa → deve aprire il dialogo di stampa correttamente
- [ ] Chiudere e riaprire la preview più volte → nessun memory leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)